### PR TITLE
Fix displaying of attributes during POST data screen

### DIFF
--- a/lib/Auth/Source/privacyidea.php
+++ b/lib/Auth/Source/privacyidea.php
@@ -246,14 +246,14 @@ class sspmod_privacyidea_Auth_Source_privacyidea extends sspmod_core_Auth_UserPa
                 if ($attribute_value) {
                     SimpleSAML_Logger::debug("privacyidea Mapped key in response");
                     $attributes[$mapped_key] = array($attribute_value);
-                    SimpleSAML_Logger::debug("privacyidea      value: " . print_r($attributes[$mapped_key]));
+                    SimpleSAML_Logger::debug("privacyidea      value: " . print_r($attributes[$mapped_key], TRUE));
                 }
             } else {
                 // We have no keymapping and just transfer the attribute
                 SimpleSAML_Logger::debug("privacyidea unmapped key: " . $key);
                 if ($user_attributes->$key) {
                     $attributes[$key] = array($user_attributes->$key);
-                    SimpleSAML_Logger::debug("privacyidea        value: " . print_r($attributes[$key]));
+                    SimpleSAML_Logger::debug("privacyidea        value: " . print_r($attributes[$key], TRUE));
                 }
             }
         }


### PR DESCRIPTION
This removes the displaying of attributes after the user has logged in and fixes #11.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/13?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/13'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>