### PR TITLE
Add possibility to specify further attributes for SAML mapping

### DIFF
--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -70,7 +70,7 @@ Then you need to add the authentication source 'privacyidea:privacyidea' to
 
 User attributes
 ---------------
-At the moment privacyIDEA will know and return the following attributes, 
+At the moment privacyIDEA will know and return the following attributes by default, 
 that can be mapped to SAML attributes:
 
 username:	The login name
@@ -80,3 +80,6 @@ mobile:		The mobile phone number of the user as it is retrieved from the user so
 phone:		The phone number of the user as it is retrieved from the user source
 email:		The email address of the user as it is retrieved from the user source                                
                                 
+The list can be extended by including custom attributes in the attributemap. If the 
+privacyIDEA server returns an attribute 'groups', you can map that to 'groups' if
+you include it in the attributemap. Otherwise, it is discarded.

--- a/lib/Auth/Source/privacyidea.php
+++ b/lib/Auth/Source/privacyidea.php
@@ -2,6 +2,8 @@
 
 /**
  * privacyidea authentication module.
+ * 2016-12-30 Andreas Böhler <dev@rnb-consulting.at>
+ *            Add support for passing additional attributes to SAML
  * 2015-11-21 Cornelius Kölbel <cornelius.koelbel@netknights.it>
  *            Add support for U2F authentication requests
  * 2015-11-19 Cornelius Kölbel <cornelius.koelbel@netknights.it>
@@ -234,6 +236,8 @@ class sspmod_privacyidea_Auth_Source_privacyidea extends sspmod_core_Auth_UserPa
         /* If we get this far, we have a valid login. */
         $attributes = array();
         $arr = array("username", "surname", "email", "givenname", "mobile", "phone", "realm", "resolver");
+        // Add all additional attributes defined in the array map to the search array
+        $arr = array_merge(array_diff(array_keys($this->attributemap), $arr), $arr);
         reset($arr);
         foreach ($arr as $key) {
             SimpleSAML_Logger::debug("privacyidea        key: " . $key);

--- a/lib/Auth/Source/privacyidea.php
+++ b/lib/Auth/Source/privacyidea.php
@@ -237,7 +237,7 @@ class sspmod_privacyidea_Auth_Source_privacyidea extends sspmod_core_Auth_UserPa
         $attributes = array();
         $arr = array("username", "surname", "email", "givenname", "mobile", "phone", "realm", "resolver");
         // Add all additional attributes defined in the array map to the search array
-        $arr = array_merge(array_diff(array_keys($this->attributemap), $arr), $arr);
+        $arr = array_merge(array_keys($this->attributemap), $arr);
         reset($arr);
         foreach ($arr as $key) {
             SimpleSAML_Logger::debug("privacyidea        key: " . $key);


### PR DESCRIPTION
This allows to specify further attributes on the attributemap configuration. Only attributes configured here are added to the SAML response, all others are left untouched. Closes #12
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23discussion_r94240347%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23issuecomment-269791496%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23discussion_r94251482%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23discussion_r94270716%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23discussion_r94271438%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23issuecomment-269857898%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23issuecomment-269857987%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23issuecomment-269946468%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23issuecomment-269791496%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20a%20lot%20for%20the%20PR.%20A%20comment%20like%5Cr%5Cn%5Cr%5CnCloses%20%2312%20%5Cr%5Cn%5Cr%5CnWill%20automatically%20close%20the%20issue%20%2312%20on%20submit.%22%2C%20%22created_at%22%3A%20%222016-12-30T16%3A31%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20seems%20that%20one%20can%27t%20close%20issues%20by%20mentioning%20it%20in%20the%20commit%20message%21%3F%20I%27m%20used%20to%20phabricator%2C%20where%20this%20works%20perfectly%20fine.%20%5Cr%5CnAnyhow%2C%20this%20should%20now%20close%20%2312.%22%2C%20%22created_at%22%3A%20%222016-12-31T09%3A49%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3099753%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/andyboeh%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-12-31T09%3A52%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3099753%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/andyboeh%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20a%20lot%21%22%2C%20%22created_at%22%3A%20%222017-01-02T08%3A57%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20d29f34f1eb5c5e02f24c358fd873d40e5e371e0d%20lib/Auth/Source/privacyidea.php%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14%23discussion_r94240347%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22According%20to%20http%3A//php.net/manual/en/function.array-merge.php%20dublicate%20keys%20in%20the%20array%20will%20be%20overwritten.%20So%20I%20guess%20we%20can%20skip%20the%20%2Aarray_diff%2A%20and%20%20and%20just%20do%5Cr%5Cn%5Cr%5Cn%20%20%20%20%24arr%20%3D%20array_merge%28array_keys%28%24this-%3Eattributemap%29%2C%20%24arr%29%3B%5Cr%5Cn%5Cr%5CnTo%20my%20understanding%20there%20will%20be%20no%20dublicate%20values%3F%22%2C%20%22created_at%22%3A%20%222016-12-30T16%3A30%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20are%20completely%20right%2C%20I%20did%20not%20read%20the%20documentation%20thoroughly%20enough.%20Plus%2C%20the%20documentation%20needs%20updating%20to%20reflect%20the%20changed%20behaviour.%20I%27ll%20make%20a%20new%20commit%20tomorrow.%22%2C%20%22created_at%22%3A%20%222016-12-30T19%3A16%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3099753%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/andyboeh%22%7D%7D%2C%20%7B%22body%22%3A%20%22thx%22%2C%20%22created_at%22%3A%20%222016-12-31T08%3A11%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1908620%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-12-31T09%3A47%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3099753%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/andyboeh%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/Auth/Source/privacyidea.php%3AL236-244%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14#issuecomment-269791496'>General Comment</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Thanks a lot for the PR. A comment like
Closes #12
Will automatically close the issue #12 on submit.
- <a href='https://github.com/andyboeh'><img border=0 src='https://avatars.githubusercontent.com/u/3099753?v=3' height=16 width=16'></a> It seems that one can't close issues by mentioning it in the commit message!? I'm used to phabricator, where this works perfectly fine.
Anyhow, this should now close #12.
- <a href='https://github.com/andyboeh'><img border=0 src='https://avatars.githubusercontent.com/u/3099753?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> Thanks a lot!
- [x] <a href='#crh-comment-Pull d29f34f1eb5c5e02f24c358fd873d40e5e371e0d lib/Auth/Source/privacyidea.php 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14#discussion_r94240347'>File: lib/Auth/Source/privacyidea.php:L236-244</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> According to http://php.net/manual/en/function.array-merge.php dublicate keys in the array will be overwritten. So I guess we can skip the *array_diff* and  and just do
$arr = array_merge(array_keys($this->attributemap), $arr);
To my understanding there will be no dublicate values?
- <a href='https://github.com/andyboeh'><img border=0 src='https://avatars.githubusercontent.com/u/3099753?v=3' height=16 width=16'></a> You are completely right, I did not read the documentation thoroughly enough. Plus, the documentation needs updating to reflect the changed behaviour. I'll make a new commit tomorrow.
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars.githubusercontent.com/u/1908620?v=3' height=16 width=16'></a> thx


<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/14?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/14?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/14'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>