### PR TITLE
handleLogin: make parameters optional

### DIFF
--- a/lib/Auth/Source/privacyidea.php
+++ b/lib/Auth/Source/privacyidea.php
@@ -316,7 +316,7 @@ class sspmod_privacyidea_Auth_Source_privacyidea extends sspmod_core_Auth_UserPa
      * @param $clientdata
      * @throws Exception
      */
-    public static function handleLogin($authStateId, $username, $password, $transaction_id, $signaturedata, $clientdata)
+    public static function handleLogin($authStateId, $username, $password, $transaction_id = NULL, $signaturedata = NULL, $clientdata = NULL)
     {
         assert('is_string($authStateId)');
         assert('is_string($username)');


### PR DESCRIPTION
In the log we got:
```
Jun 28 22:09:24 simplesamlphp ERROR [ad6c274e50] SimpleSAML_Error_Exception: Error 2 - Declaration of sspmod_privacyidea_Auth_Source_privacyidea::handleLogin($authStateId, $username, $password, $transaction_id, $signaturedata, $clientdata) should be compatible with sspmod_core_Auth_UserPassBase::handleLogin($authStateId, $username, $password)
```
After making the parameters $transaction_id, $signaturedata, and $clientdata optional the message is no longer logged.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/20?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/20'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>