### PR TITLE
Remove english translations to fix missing text on login page

### DIFF
--- a/dictionaries/privacyidea.translation.json
+++ b/dictionaries/privacyidea.translation.json
@@ -1,46 +1,37 @@
 {
 	"header": {
-		"en": "Authenticate against privacyIDEA",
 		"de": "Anmelden gegen privacyIDEA",
 		"nl": "Authenticeer tegen privacyIDEA"
 	},
 	"login_title": {
-		"en": "Please enter your Username and your Password",
 		"de": "Bitte geben Sie Ihren Nutzernamen und Passwort ein",
 		"nl": "Vul uw inlognaam en wachtwoord in."
 	},
 	"login_text": {
-		"en": "Please note, that you need to enter both, your secret Password and the OTP value in the Password field.",
 		"de": "Bitte beachten Sie, dass Sie im Passwort-Feld Ihr geheimes Passwort und den OTP Wert eingeben müssen.",
 		"nl": "Let op vul je wachtwoord en je eenmalige wachtwoord in het wachtwoordveld."
 	},
 	"password_otp": {
-		"en": "Password + OTP",
 		"de": "Password + OTP",
 		"nl": "Wachtwoord + OTP"
 	},
 	"password": {
-		"en": "Password",
 		"de": "Password",
 		"nl": "Wachtwoord"
 	},
 	"otp": {
-		"en": "OTP",
 		"de": "Einmalpasswort",
 		"nl": "OTP"
 	},
 	"login_title_challenge": {
-		"en": "Please enter your One Time Password",
 		"de": "Bitte geben Sie Ihr Einmalpasswort ein",
 		"nl": "Vul je eenmalige wachtwoord in."
 	},
 	"otp_extra_text": {
-		"en": "Please enter your Password and One Time Password",
 		"de": "Bitte geben Sie Ihr Password und Ihr Einmalpasswort ein",
 		"nl": "Vul je wachtwoord en eenmalige wachtwoord in."
 	},
 	"login_text_challenge": {
-		"en": "You entered the correct PIN or password. But now you also need to enter a valid One Time Password as the second factor.",
 		"de": "Sie haben die korrekte PIN, bzw. das korrekte Passwort eingegeben. Aber nun müssen Sie noch ein gültiges Einmalpasswort als zweiten Faktor eingeben.",
 		"nl": "Je hebt het correcte wachtwoord ingevuld maar nu dien je nog het eenmalige wachtwoord in te vullen."
 	}


### PR DESCRIPTION
The text isn't displaying when english translations are defined in both translations and definitions. Addresses #26 and #27.  Tested with simplesamlphp 1.15.x

Before: 

<img width="961" alt="screen shot 2018-03-09 at 4 08 40 pm" src="https://user-images.githubusercontent.com/328689/37235525-2744fc94-23b4-11e8-8ac2-4f96229d32c7.png">

After:

<img width="955" alt="screen shot 2018-03-09 at 4 09 26 pm" src="https://user-images.githubusercontent.com/328689/37235539-4465666a-23b4-11e8-88c9-39c76df13aeb.png">
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/30?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/30'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>