### PR TITLE
Added concatenation in mapping

### DIFF
--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -68,6 +68,14 @@ Then you need to add the authentication source 'privacyidea:privacyidea' to
          			 'mobile' => 'mobilePhone'
          			 ),
 
+        /*
+         * You are able to concatenate attributes like the given and surname.
+         * Optional.
+         */
+         'concatenationmap' => array(
+         			'givenname,surname' => 'fullName',
+         			),
+
          /*
           * Here the detail attributes can be edited.
           * If they should not be listed, just remove them.

--- a/lib/Auth/Source/privacyidea.php
+++ b/lib/Auth/Source/privacyidea.php
@@ -71,6 +71,12 @@ class sspmod_privacyidea_Auth_Source_privacyidea extends sspmod_core_Auth_UserPa
 
 	private $detailmap = array();
 
+	/**
+	 * The concatenation map. It is an array
+	 */
+
+	private $concatenationmap = array();
+
     public function getOtpExtra()
     {
         return $this->otp_extra;
@@ -107,6 +113,9 @@ class sspmod_privacyidea_Auth_Source_privacyidea extends sspmod_core_Auth_UserPa
         }
 	    if (array_key_exists('detailmap', $config)) {
 		    $this->detailmap = $config['detailmap'];
+	    }
+	    if (array_key_exists('concatenationmap', $config)) {
+	    	$this->concatenationmap = $config['concatenationmap'];
 	    }
         if (array_key_exists('otpextra', $config)) {
             $this->otp_extra= $config['otpextra'];
@@ -320,6 +329,21 @@ class sspmod_privacyidea_Auth_Source_privacyidea extends sspmod_core_Auth_UserPa
 		        $attributes[$mapped_key] = array($attribute_value);
 	        }
 
+        }
+
+        $concatenation = array_keys($this->concatenationmap);
+        reset($concatenation);
+        foreach ($concatenation as $key) {
+        	SimpleSAML_Logger::debug("privacyidea        key: " . print_r($key, TRUE));
+        	$mapped_key = $this->concatenationmap[$key];
+        	SimpleSAML_Logger::debug("privacyidea mapped key: " . print_r($mapped_key, TRUE));
+        	$concatenationArr = explode(",", $key);
+        	$concatenationValues = array();
+        	foreach ($concatenationArr as $item) {
+        		$concatenationValues[] = $user_attributes->$item;
+	        }
+			$concatenationString = implode(" ", $concatenationValues);
+			$attributes[$mapped_key] = array($concatenationString);
         }
 
         SimpleSAML_Logger::debug("privacyidea Array returned: " . print_r($attributes, True));


### PR DESCRIPTION
closes #23 
Useful to get the full name in one line instead of separating sur and given name.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/35%23discussion_r215173998%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2074160562014882e0d4f8293b98b15ac9d47fb1aa%20docs/privacyidea.txt%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/35%23discussion_r215173998%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cr%5Cn%40Mipronimo%20%20This%20is%20all%20perfect.%5Cr%5CnBut%20I%20am%20wondering%2C%20if%20we%20%28I%29%20have%20chosen%20a%20bad%20to%20remember%20configuration%20way%20in%20the%20first%20place.%5Cr%5Cn%5Cr%5CnIt%20felt%20more%20intuitive%20to%20me%20to%20configure%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Ephp%5Cr%5Cn%20%20%20%20fullName%20%3D%3E%20givenname%2Csurname%5Cr%5Cn%7E%7E%7E%7E%5Cr%5Cn%5Cr%5Cnsince%20fullName%20is%20constructed%20from%20these%20both.%5Cr%5Cn%5Cr%5CnBut%20it%20is%20right.%20In%20this%20sense%20the%20attributemap%20would%20also%20be%20the%20wrong%20way%3A%5Cr%5Cn%5Cr%5CnThe%20SAML%20attribute%20%5C%22samlLoginName%5C%22%20would%20be%20filled%20by%20the%20privacyIDEA%20return%20value%20%5C%22username%5C%22%3A%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Ephp%5Cr%5Cn%20%20%20%20%20%5C%22samlLoginName%5C%22%20%3D%3E%20%5C%22username%5C%22%5Cr%5Cn%7E%7E%7E%7E%22%2C%20%22created_at%22%3A%20%222018-09-05T08%3A14%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20docs/privacyidea.txt%3AL68-82%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 74160562014882e0d4f8293b98b15ac9d47fb1aa docs/privacyidea.txt 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/35#discussion_r215173998'>File: docs/privacyidea.txt:L68-82</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> @Mipronimo  This is all perfect.
But I am wondering, if we (I) have chosen a bad to remember configuration way in the first place.
It felt more intuitive to me to configure
~~~~php
fullName => givenname,surname
~~~~
since fullName is constructed from these both.
But it is right. In this sense the attributemap would also be the wrong way:
The SAML attribute "samlLoginName" would be filled by the privacyIDEA return value "username":
~~~~php
"samlLoginName" => "username"
~~~~


<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/35?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/35?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/35'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>