### PR TITLE
Add enabled key

### DIFF
--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -137,8 +137,8 @@ Use the following example:
     'class'             => 'privacyidea:privacyidea',
 
   // Other authproc filters can disable 2FA if you want to.
-  // If privacyIDEA should listen to the setting, you have to enter the state's path and key,
-  // which will be edit by previous auth proc filters.
+  // If privacyIDEA should listen to the setting, you have to enter the state's path and key.
+  // The value of this key will be set by a previous auth proc filger.
   // privacyIDEA will only be disabled, if the value of the key is set to false,
   // in any other situation (e.g. the key is not set or does not exist), privacyIDEA will be enabled.
     'enabledPath'       => '',

--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -137,7 +137,8 @@ Use the following example:
     'class'             => 'privacyidea:privacyidea',
 
   // Other authproc filters can disable 2FA if you want to.
-  // For that you need to enter the path end the key, which should be true or false.
+  // If privacyIDEA should listen to the setting, you have to enter the state's path and key,
+  // which will be edit by previous auth proc filters.
   // privacyIDEA will only be disabled, if the value of the key is set to false,
   // in any other situation (e.g. the key is not set or does not exist), privacyIDEA will be enabled.
     'enabledPath'       => '',

--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -138,7 +138,8 @@ Use the following example:
 
   // Other authproc filters can disable 2FA if you want to.
   // For that you need to enter the path end the key, which should be true or false.
-  // If it is not set, privacyIDEA will be enadbled
+  // privacyIDEA will only be disabled, if the value of the key is set to false,
+  // in any other situation (e.g. the key is not set or does not exist), privacyIDEA will be enabled.
     'enabledPath'       => '',
     'enabledKey'        => '',
 

--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -136,6 +136,12 @@ Use the following example:
   // You must not change the class name
     'class'             => 'privacyidea:privacyidea',
 
+  // Other authproc filters can disable 2FA if you want to.
+  // For that you need to enter the path end the key, which should be true or false.
+  // If it is not set, privacyIDEA will be enadbled
+    'enabledPath'       => '',
+    'enabledKey'        => '',
+
   // This is the URL to your privacyidea server
     'privacyideaserver' => 'https://privacyidea.local',
 

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -91,7 +91,7 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
      */
     public function process(&$state)
     {
-	    SimpleSAML_Logger::info("privacyIDEA Auth Proc Filter: running process");
+	    SimpleSAML_Logger::info("privacyIDEA Auth Proc Filter: Entering process function");
     	$state['privacyidea:privacyidea'] = array(
     		'privacyIDEA_URL' => $this->privacyIDEA_URL,
 		    'sslverifyhost' => $this->sslverifyhost,

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -43,8 +43,13 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 	private $uidKey;
 
 	/**
+	 * enabledPath
+	 * If a different authproc should be able to turn on or off privacyIDEA, the path to the key be entered here.
+	 */
+	private $enabledPath;
+
+	/**
 	 * enabledKey
-	 * If a different authproc should be able to turn on or off privacyIDEA, the key for it can be entered here.
 	 * If it's true, we will do 2FA.
 	 */
 	private $enabledKey;
@@ -73,7 +78,8 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
         $this->sslverifypeer = $cfg->getBoolean('sslverifypeer', true);
         $this->realm = $cfg->getString('realm');
         $this->uidKey = $cfg->getString('uidKey');
-        $this->enabledKey = $cfg->getString('enabledKey', 'pienabled');
+        $this->enabledPath = $cfg->getString('enabledPath', 'privacyIDEA');
+        $this->enabledKey = $cfg->getString('enabledKey', 'enabled');
      }
 
     /**
@@ -94,8 +100,8 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 		    'uidKey' => $this->uidKey,
 	    );
 
-    	if(isset($state["Attributes"][$this->enabledKey][0])) {
-    		$piEnabled = $state["Attributes"][$this->enabledKey][0];
+    	if(isset($state[$this->enabledPath][$this->enabledKey][0])) {
+    		$piEnabled = $state[$this->enabledPath][$this->enabledKey][0];
 	    } else {
     		$piEnabled = True;
 	    }
@@ -106,7 +112,7 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 			$url = SimpleSAML_Module::getModuleURL( 'privacyidea/otpform.php' );
 			SimpleSAML_Utilities::redirectTrustedURL( $url, array( 'StateId' => $id ) );
 		} else {
-			SimpleSAML_Logger::debug("privacyIDEA: " . $this->enabledKey . " is set to false -> privacyIDEA is disabled");
+			SimpleSAML_Logger::debug("privacyIDEA: " . $this->enabledPath . " -> " . $this->enabledKey . " is not set to true -> privacyIDEA is disabled");
 		}
     }
 


### PR DESCRIPTION
This makes it possible for other authproc filters to disable privacyIDEA in simpleSAMLphp
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/43%23discussion_r241051828%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/43%23discussion_r241053484%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%209dd1a6160ae68780b700bc8a7c80ba3e5fd59065%20docs/privacyidea.txt%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/43%23discussion_r241053484%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20be%20a%20bit%20more%20specific%20here%20in%20regards%20to%20%5C%22the%20path%20and%20the%20key%5C%22.%5Cr%5CnLike%20the%20path%20and%20the%20key%20in%20the%20state%20object%20passed%20by%20the%20previous%20auth%20proc%20filter.%22%2C%20%22created_at%22%3A%20%222018-12-12T15%3A13%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20docs/privacyidea.txt%3AL136-149%22%7D%2C%20%22Pull%209dd1a6160ae68780b700bc8a7c80ba3e5fd59065%20lib/Auth/Process/privacyidea.php%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/43%23discussion_r241051828%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Reading%20%5C%22running%20process%5C%22%20in%20a%20log%20file%20might%20be%20a%20bit%20misleading.%5Cr%5CnWe%20should%20change%20this%20to%20something%20like%20%5C%22entering%20function%20%27process%27%5C%22.%22%2C%20%22created_at%22%3A%20%222018-12-12T15%3A09%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/Auth/Process/privacyidea.php%3AL91-98%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 9dd1a6160ae68780b700bc8a7c80ba3e5fd59065 lib/Auth/Process/privacyidea.php 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/43#discussion_r241051828'>File: lib/Auth/Process/privacyidea.php:L91-98</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Reading "running process" in a log file might be a bit misleading.
We should change this to something like "entering function 'process'".
- [x] <a href='#crh-comment-Pull 9dd1a6160ae68780b700bc8a7c80ba3e5fd59065 docs/privacyidea.txt 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/43#discussion_r241053484'>File: docs/privacyidea.txt:L136-149</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Please be a bit more specific here in regards to "the path and the key".
Like the path and the key in the state object passed by the previous auth proc filter.


<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/43?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/43?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/43'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>