### PR TITLE
Fix U2F in auth proc filters

### DIFF
--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -140,39 +140,39 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 
 	    if ($status !== true) {
 		    throw new SimpleSAML_Error_BadRequest("privacyIDEA: Valid JSON response, but some internal error occured in PI server");
-	    } else {
-		    if ( $auth !== true ) {
-			    SimpleSAML_Logger::debug( "Throwing WRONGUSERPASS" );
-			    $detail = $body->detail;
-			    $message = $detail->message;
-			    if (property_exists($detail, "transaction_id")){
-				    $transaction_id = $detail->transaction_id;
-			    }
-			    if (property_exists( $detail, "attributes")){
-				    $attributes = $detail->attributes;
-				    if (property_exists( $attributes, "u2fSignRequest")){
-					    SimpleSAML_Logger::debug("This is an U2F authentication request");
-					    SimpleSAML_Logger::debug(print_r($attributes, true));
-					    /*
-						 * In case of U2F the $attributes looks like this:
-						[img] => static/css/FIDO-U2F-Security-Key-444x444.png#012
-						[hideResponseInput] => 1#012
-						[u2fSignRequest] => [challenge] => yji-PL1V0QELilDL3m6Lc-1yahpKZiU-z6ye5Zz2mp8#012
-									[version] => U2F_V2#012
-									[keyHandle] => fxDKTr6o8EEGWPyEyRVDvnoeA0c6v-dgvbN-6Mxc6XBmEItsw#012
-									[appId] => https://172.16.200.138#012        )#012#012)
-						*/
-				    }
-			    }
-			    if ($transaction_id){
-				    /* If we have a transaction_id, we do challenge response */
-				    SimpleSAML_Logger::debug( "Throwing CHALLENGERESPONSE" );
-				    throw new SimpleSAML_Error_Error(array("CHALLENGERESPONSE", $transaction_id, $message, $attributes));
-			    }
-			    SimpleSAML_Logger::debug( "Throwing WRONGUSERPASS" );
-			    throw new SimpleSAML_Error_Error( "WRONGUSERPASS" );
-		    }
 	    }
+	    if ( $auth !== true ) {
+		    SimpleSAML_Logger::debug( "Throwing WRONGUSERPASS" );
+		    $detail = $body->detail;
+		    $message = $detail->message;
+		    if (property_exists($detail, "transaction_id")){
+			    $transaction_id = $detail->transaction_id;
+		    }
+		    if (property_exists( $detail, "attributes")){
+			    $attributes = $detail->attributes;
+			    if (property_exists( $attributes, "u2fSignRequest")){
+				    SimpleSAML_Logger::debug("This is an U2F authentication request");
+				    SimpleSAML_Logger::debug(print_r($attributes, true));
+				    /*
+					 * In case of U2F the $attributes looks like this:
+					[img] => static/css/FIDO-U2F-Security-Key-444x444.png#012
+					[hideResponseInput] => 1#012
+					[u2fSignRequest] => [challenge] => yji-PL1V0QELilDL3m6Lc-1yahpKZiU-z6ye5Zz2mp8#012
+								[version] => U2F_V2#012
+								[keyHandle] => fxDKTr6o8EEGWPyEyRVDvnoeA0c6v-dgvbN-6Mxc6XBmEItsw#012
+								[appId] => https://172.16.200.138#012        )#012#012)
+					*/
+			    }
+		    }
+		    if ($transaction_id){
+			    /* If we have a transaction_id, we do challenge response */
+			    SimpleSAML_Logger::debug( "Throwing CHALLENGERESPONSE" );
+			    throw new SimpleSAML_Error_Error(array("CHALLENGERESPONSE", $transaction_id, $message, $attributes));
+		    }
+		    SimpleSAML_Logger::debug( "Throwing WRONGUSERPASS" );
+		    throw new SimpleSAML_Error_Error( "WRONGUSERPASS" );
+		}
+
 	    SimpleSAML_Logger::debug( "privacyIDEA: User authenticated successfully" );
 	    return true;
     }

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -104,7 +104,7 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
      * length.
      */
 
-    public static function authenticate(array &$state, $otp)
+    public static function authenticate(array &$state, $otp, $transaction_id, $signaturedata, $clientdata)
     {
 
 	    $cfg = $state['privacyidea:privacyidea'];
@@ -114,8 +114,20 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 		    "pass" => $otp,
 		    "realm"=> $cfg['realm'],
 	    );
-
+        if ($transaction_id) {
+            SimpleSAML_Logger::debug("Authenticating with transaction_id: " . $transaction_id);
+            $params["transaction_id"] = $transaction_id;
+        }
+        if ($signaturedata) {
+            SimpleSAML_Logger::debug("Authenticating with signaturedata: " . urlencode($signaturedata));
+            $params["signaturedata"] = $signaturedata;
+        }
+        if ($clientdata) {
+            SimpleSAML_Logger::debug("Authenticating with clientdata: " . urlencode($clientdata));
+            $params["clientdata"] = $clientdata;
+        }
 	    $body = sspmod_privacyidea_Auth_utils::curl($params, null, $cfg, "/validate/samlcheck", true);
+		$attributes = NULL;
 
 	    try {
 		    $result = $body->result;
@@ -129,15 +141,40 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 	    if ($status !== true) {
 		    throw new SimpleSAML_Error_BadRequest("privacyIDEA: Valid JSON response, but some internal error occured in PI server");
 	    } else {
-		    if ($auth !== true) {
-			    SimpleSAML_Logger::debug( "privacyIDEA: Wrong user pass" );
-			    return false;
-		    } else {
-			    SimpleSAML_Logger::debug( "privacyIDEA: User authenticated successfully" );
-			    return true;
+		    if ( $auth !== true ) {
+			    SimpleSAML_Logger::debug( "Throwing WRONGUSERPASS" );
+			    $detail = $body->detail;
+			    $message = $detail->message;
+			    if (property_exists($detail, "transaction_id")){
+				    $transaction_id = $detail->transaction_id;
+			    }
+			    if (property_exists( $detail, "attributes")){
+				    $attributes = $detail->attributes;
+				    if (property_exists( $attributes, "u2fSignRequest")){
+					    SimpleSAML_Logger::debug("This is an U2F authentication request");
+					    SimpleSAML_Logger::debug(print_r($attributes, true));
+					    /*
+						 * In case of U2F the $attributes looks like this:
+						[img] => static/css/FIDO-U2F-Security-Key-444x444.png#012
+						[hideResponseInput] => 1#012
+						[u2fSignRequest] => [challenge] => yji-PL1V0QELilDL3m6Lc-1yahpKZiU-z6ye5Zz2mp8#012
+									[version] => U2F_V2#012
+									[keyHandle] => fxDKTr6o8EEGWPyEyRVDvnoeA0c6v-dgvbN-6Mxc6XBmEItsw#012
+									[appId] => https://172.16.200.138#012        )#012#012)
+						*/
+				    }
+			    }
+			    if ($transaction_id){
+				    /* If we have a transaction_id, we do challenge response */
+				    SimpleSAML_Logger::debug( "Throwing CHALLENGERESPONSE" );
+				    throw new SimpleSAML_Error_Error(array("CHALLENGERESPONSE", $transaction_id, $message, $attributes));
+			    }
+			    SimpleSAML_Logger::debug( "Throwing WRONGUSERPASS" );
+			    throw new SimpleSAML_Error_Error( "WRONGUSERPASS" );
 		    }
 	    }
-
-
+	    SimpleSAML_Logger::debug( "privacyIDEA: User authenticated successfully" );
+	    return true;
     }
+
 }

--- a/lib/Auth/Source/privacyidea.php
+++ b/lib/Auth/Source/privacyidea.php
@@ -195,9 +195,6 @@ class sspmod_privacyidea_Auth_Source_privacyidea extends sspmod_core_Auth_UserPa
                 SimpleSAML_Logger::debug("Throwing WRONGUSERPASS");
                 $detail = $body->detail;
                 $message = $detail->message;
-                if (property_exists($detail, "transaction_id")) {
-                    $transaction_id = $detail->transaction_id;
-                }
                 if (property_exists($detail, "attributes")) {
                     $attributes = $detail->attributes;
                     if (property_exists($attributes, "u2fSignRequest")) {
@@ -214,7 +211,8 @@ class sspmod_privacyidea_Auth_Source_privacyidea extends sspmod_core_Auth_UserPa
                         */
                     }
                 }
-                if ($transaction_id) {
+                if (property_exists($detail, "transaction_id")) {
+                	$transaction_id = $detail->transaction_id;
                     /* If we have a transaction_id, we do challenge response */
                     SimpleSAML_Logger::debug("Throwing CHALLENGERESPONSE");
                     throw new SimpleSAML_Error_Error(array("CHALLENGERESPONSE", $transaction_id, $message, $attributes));

--- a/templates/loginform.php
+++ b/templates/loginform.php
@@ -40,7 +40,7 @@ if ($this->data['errorcode'] === "CHALLENGERESPONSE") {
 
 if ($u2fSignRequest) {
     // Add javascript for U2F support before including the header.
-    $this->data['head'] = '<script type="text/javascript" src="' . htmlspecialchars(SimpleSAML_Module::getModuleUrl('privacyidea/js/u2f-api.js')) . '"></script>\n';
+    $this->data['head'] = '<script type="text/javascript" src="' . htmlspecialchars(SimpleSAML_Module::getModuleUrl('privacyidea/js/u2f-api.js')) . '"></script>';
     $this->data['head'] .= '<script type="text/javascript" src="' . htmlspecialchars(SimpleSAML_Module::getModuleUrl('privacyidea/js/u2f.js')) . '"></script>';
 }
 

--- a/templates/loginform.php
+++ b/templates/loginform.php
@@ -1,9 +1,18 @@
 <?php
 if(isset($this->data['auth_proc_filter_scenario'])) {
-    $this->data['errorcode'] = NULL;
-    $this->data['otp_extra'] = NULL;
-    $this->data['username'] = NULL;
-    $this->data['stateparams'] = NULL;
+	if (!isset($this->data['errorcode'])) {
+		$this->data['errorcode'] = null;
+	}
+	if (!isset($this->data['username'])) {
+		$this->data['username'] = null;
+	}
+	if (!isset($this->data['stateparams'])) {
+		$this->data['stateparams'] = null;
+	}
+	if (!isset($this->data['transaction_id'])) {
+	    $this->data['transaction_id'] = null;
+    }
+	$this->data['otp_extra'] = NULL;
 } else {
     $this->data['auth_proc_filter_scenario'] = 0;
 }
@@ -85,9 +94,6 @@ if ($this->data['errorcode'] !== NULL && $this->data['errorcode'] !== "CHALLENGE
             <div class="form-panel first valid" id="gaia_firstform">
                 <div class="slide-out ">
                     <div class="input-wrapper focused">
-                        <?php
-                                if(!$this->data['auth_proc_filter_scenario']) {
-                        ?>
                         <!-- per line we have an identifier-shown -->
                         <div class="identifier-shown">
                             <?php
@@ -104,33 +110,35 @@ if ($this->data['errorcode'] !== NULL && $this->data['errorcode'] !== "CHALLENGE
                                 echo '</label>';
                             }
                             ?>
-
                             <?php
-                            if ($this->data['rememberUsernameEnabled'] || $this->data['rememberMeEnabled']) {
-                                $rowspan = 1;
-                            } elseif (array_key_exists('organizations', $this->data)) {
-                                $rowspan = 3;
-                            } else {
-                                $rowspan = 2;
+                            if(!$this->data['auth_proc_filter_scenario']) {
+	                            if ( $this->data['rememberUsernameEnabled'] || $this->data['rememberMeEnabled'] ) {
+		                            $rowspan = 1;
+	                            } elseif ( array_key_exists( 'organizations', $this->data ) ) {
+		                            $rowspan = 3;
+	                            } else {
+		                            $rowspan = 2;
+	                            }
+	                            ?>
+
+	                            <?php
+	                            if ( $this->data['rememberUsernameEnabled'] || $this->data['rememberMeEnabled'] ) {
+		                            if ( $this->data['rememberUsernameEnabled'] ) {
+			                            echo str_repeat( "\t", 4 );
+			                            echo '<input type="checkbox" id="remember_username" tabindex="4" name="remember_username" value="Yes" ';
+			                            echo $this->data['rememberUsernameChecked'] ? 'checked="Yes" /> ' : '/> ';
+			                            echo htmlspecialchars( $this->t( '{login:remember_username}' ) );
+		                            }
+		                            if ( $this->data['rememberMeEnabled'] ) {
+			                            echo str_repeat( "\t", 4 );
+			                            echo '<input type="checkbox" id="remember_me" tabindex="4" name="remember_me" value="Yes" ';
+			                            echo $this->data['rememberMeChecked'] ? 'checked="Yes" /> ' : '/> ';
+			                            echo htmlspecialchars( $this->t( '{login:remember_me}' ) );
+		                            }
+	                            }
                             }
                             ?>
 
-                            <?php
-                            if ($this->data['rememberUsernameEnabled'] || $this->data['rememberMeEnabled']) {
-                                if ($this->data['rememberUsernameEnabled']) {
-                                    echo str_repeat("\t", 4);
-                                    echo '<input type="checkbox" id="remember_username" tabindex="4" name="remember_username" value="Yes" ';
-                                    echo $this->data['rememberUsernameChecked'] ? 'checked="Yes" /> ' : '/> ';
-                                    echo htmlspecialchars($this->t('{login:remember_username}'));
-                                }
-                                if ($this->data['rememberMeEnabled']) {
-                                    echo str_repeat("\t", 4);
-                                    echo '<input type="checkbox" id="remember_me" tabindex="4" name="remember_me" value="Yes" ';
-                                    echo $this->data['rememberMeChecked'] ? 'checked="Yes" /> ' : '/> ';
-                                    echo htmlspecialchars($this->t('{login:remember_me}'));
-                                }
-                            }
-                            ?>
 
                         </div>
                         <div class="identifier-shown">
@@ -150,14 +158,10 @@ if ($this->data['errorcode'] !== NULL && $this->data['errorcode'] !== "CHALLENGE
                             ?>
 
                         </div>
-                        <?php
-                        }
-                        ?>
                         <div class="identifier-shown">
                             <?php
                                 // otp_extra == 1
-                                if ($this->data["otp_extra"] == 1 ||
-                                    $this->data['auth_proc_filter_scenario']) {
+                                if ($this->data["otp_extra"] == 1) {
                                     if (isset($this->data['tokenQR'])) {
 	                                    echo htmlspecialchars($this->t('{privacyidea:privacyidea:scanTokenQR}'));
 	                                    ?>

--- a/templates/loginform.php
+++ b/templates/loginform.php
@@ -151,6 +151,14 @@ if ($this->data['errorcode'] !== NULL && $this->data['errorcode'] !== "CHALLENGE
                                 echo '<td style="padding: .3em;" colspan="2">' . htmlspecialchars($chal_resp_message) . '</td>';
                             } else {
                                 // normal login
+	                            if (isset($this->data['tokenQR'])) {
+		                            echo htmlspecialchars($this->t('{privacyidea:privacyidea:scanTokenQR}'));
+		                            ?>
+                                    <div class="tokenQR">
+			                            <?php echo '<img src="' . $this->data['tokenQR'] . '" />';?>
+                                    </div>
+		                            <?php
+	                            }
                                 echo '<td><label for="password">';
                                 echo '<input id="password" type="password" tabindex="2" name="password" placeholder="' . htmlspecialchars($password_text) . '" />';
                                 echo '</label></td>';
@@ -162,14 +170,6 @@ if ($this->data['errorcode'] !== NULL && $this->data['errorcode'] !== "CHALLENGE
                             <?php
                                 // otp_extra == 1
                                 if ($this->data["otp_extra"] == 1) {
-                                    if (isset($this->data['tokenQR'])) {
-	                                    echo htmlspecialchars($this->t('{privacyidea:privacyidea:scanTokenQR}'));
-	                                    ?>
-	                                    <div class="tokenQR">
-	                                        <?php echo '<img src="' . $this->data['tokenQR'] . '" />';?>
-	                                    </div>
-                                        <?php
-                                    }
                                     echo '<label for="OTP">';
                                     echo '<input type="password" id="OTP" tabindex="2" name="OTP" ';
                                     echo ' placeholder="' . htmlspecialchars($this->t('{privacyidea:privacyidea:otp}')) . '" />';

--- a/www/otpform.php
+++ b/www/otpform.php
@@ -5,17 +5,52 @@
 	} catch (Exception $e){
 	}
 
-	if(isset($_POST['OTP'])) {
+	if(isset($_REQUEST['password']) || isset($_REQUEST['username'])) {
+		if (array_key_exists('transaction_id', $_REQUEST)) {
+            $transaction_id = (string)$_REQUEST['transaction_id'];
+		} else {
+            $transaction_id = '';
+		}
+		$signatureData = '';
+		if (array_key_exists('signatureData', $_REQUEST)){
+            $signatureData = (string)$_REQUEST['signatureData'];
+            SimpleSAML_Logger::debug("signaturedata: " . $signatureData);
+		}
+		$clientData = '';
+		if (array_key_exists('clientData', $_REQUEST)) {
+            $clientData = (string)$_REQUEST['clientData'];
+            SimpleSAML_Logger::debug("clientdata: " . $clientData);
+		}
+		if (isset($_REQUEST['password'])) {
+			$password = $_REQUEST['password'];
+		} else {
+			$password = NULL;
+		}
+
 	    try {
-		    if(sspmod_privacyidea_Auth_Process_privacyidea::authenticate($state, $_POST['OTP'])) {
+		    if(sspmod_privacyidea_Auth_Process_privacyidea::authenticate($state, $password, $transaction_id, $signatureData, $clientData)) {
 			    SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea:init');
 			    SimpleSAML_Auth_ProcessingChain::resumeProcessing($state);
 		    } else {
 			    SimpleSAML_Logger::debug("privacyIDEA: User entered wrong OTP");
 		    }
-        } catch (Exception $e){
-	        echo $e;
-        }
+        } catch (SimpleSAML_Error_Error $e) {
+            /* Login failed. Extract error code and parameters, to display the error. */
+            $errorCode = $e->getErrorCode();
+            $errorParams = $e->getParameters();
+            SimpleSAML_Logger::debug("Login failed. Catching errorCode: ". $errorCode);
+            if ($errorCode === "CHALLENGERESPONSE" ) {
+	            /* In case of challenge response we do not change the username */
+	            $uidKey = $state['privacyidea:privacyidea']['uidKey'];
+	            $username = $state['Attributes'][$uidKey][0];
+	            $transaction_id = $errorParams[1];
+	            $message = $errorParams[2];
+	            $attributes = $errorParams[3];
+	            SimpleSAML_Logger::debug("Challenge Response transaction_id: ". $errorParams[1]);
+	            SimpleSAML_Logger::debug("Challenge Response message: ". $errorParams[2]);
+	            SimpleSAML_Logger::debug("Challenge Response attributes: ". print_r($attributes, TRUE));
+	        }
+		}
 	}
 
 	$cfg = SimpleSAML_Configuration::getInstance();
@@ -27,6 +62,19 @@
 		$tpl->data['tokenQR'] = null;
 	}
 	$tpl->data['params'] = array('StateId' => $authStateId);
+
+
+	if (isset($username)) {
+        $tpl->data['transaction_id'] = $transaction_id;
+        $tpl->data['chal_resp_message'] = $message;
+        $tpl->data['chal_resp_attributes'] = $attributes;
+        $tpl->data['errorcode'] = $errorCode;
+		$tpl->data['errorparams'] = $errorParams;
+	}
+	$tpl->data['forceUsername'] = TRUE;
+	$tpl->data['rememberUsernameEnabled'] = TRUE;
+	$tpl->data['rememberUsernameChecked'] = TRUE;
+
 	$tpl->show();
 
 	?>


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47%23discussion_r245657291%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47%23discussion_r245658193%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47%23discussion_r245658774%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47%23discussion_r245662626%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20cfc44f51d3dea5795e69f30d392c9804d98c7cb3%20lib/Auth/Process/privacyidea.php%2089%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47%23discussion_r245657291%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20%60%60throw%60%60%20in%20line%20142%20exit%20the%20code%3F%5Cr%5Cn%5Cr%5CnThen%20we%20can%20omit%20the%20else%20branch%20and%20have%20the%20%60%60if%20%28%24auth%20%21%3D%3D%20true%29%60%60%20on%20the%20same%20level%20like%20%60%60if%20%28%24status%20%21%3D%3D%20true%29%60%60.%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222019-01-07T13%3A46%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/Auth/Process/privacyidea.php%3AL104-181%22%7D%2C%20%22Pull%20cfc44f51d3dea5795e69f30d392c9804d98c7cb3%20lib/Auth/Process/privacyidea.php%20101%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47%23discussion_r245658193%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Currently%20we%20do%20nothing%20in%20this%20branch%20except%20logging%2C%20that%20we%20have%20a%20u2f%20authentication.%5Cr%5CnI%20can%20not%20remember%20-%20is%20this%20correct%3F%22%2C%20%22created_at%22%3A%20%222019-01-07T13%3A49%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/Auth/Process/privacyidea.php%3AL104-181%22%7D%2C%20%22Pull%20cfc44f51d3dea5795e69f30d392c9804d98c7cb3%20templates/loginform.php%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47%23discussion_r245662626%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20is%20the%20data%20not%20reset%20anymire%2C%20if%20it%20exists%3F%22%2C%20%22created_at%22%3A%20%222019-01-07T14%3A03%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20templates/loginform.php%3AL1-19%22%7D%2C%20%22Pull%20cfc44f51d3dea5795e69f30d392c9804d98c7cb3%20lib/Auth/Process/privacyidea.php%20113%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47%23discussion_r245658774%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22should%20we%20add%20the%20lines%20148%20-%20150%20in%20this%20if-branch%2C%20so%20that%20we%20only%20have%20two%20if-branches%20on%20this%20level%2C%20and%20not%20three.%5Cr%5Cn%28we%20check%20for%20the%20transaction_id%20two%20times%29%22%2C%20%22created_at%22%3A%20%222019-01-07T13%3A51%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/Auth/Process/privacyidea.php%3AL104-181%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull cfc44f51d3dea5795e69f30d392c9804d98c7cb3 lib/Auth/Process/privacyidea.php 89'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47#discussion_r245657291'>File: lib/Auth/Process/privacyidea.php:L104-181</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Does ``throw`` in line 142 exit the code?
Then we can omit the else branch and have the ``if ($auth !== true)`` on the same level like ``if ($status !== true)``.
- [x] <a href='#crh-comment-Pull cfc44f51d3dea5795e69f30d392c9804d98c7cb3 lib/Auth/Process/privacyidea.php 101'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47#discussion_r245658193'>File: lib/Auth/Process/privacyidea.php:L104-181</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Currently we do nothing in this branch except logging, that we have a u2f authentication.
I can not remember - is this correct?
- [x] <a href='#crh-comment-Pull cfc44f51d3dea5795e69f30d392c9804d98c7cb3 lib/Auth/Process/privacyidea.php 113'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47#discussion_r245658774'>File: lib/Auth/Process/privacyidea.php:L104-181</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> should we add the lines 148 - 150 in this if-branch, so that we only have two if-branches on this level, and not three.
(we check for the transaction_id two times)
- [x] <a href='#crh-comment-Pull cfc44f51d3dea5795e69f30d392c9804d98c7cb3 templates/loginform.php 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47#discussion_r245662626'>File: templates/loginform.php:L1-19</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Why is the data not reset anymire, if it exists?


<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/47?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/47?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/47'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>