### PR TITLE
Fixed missing error messages

### DIFF
--- a/www/otpform.php
+++ b/www/otpform.php
@@ -68,7 +68,9 @@
         $tpl->data['transaction_id'] = $transaction_id;
         $tpl->data['chal_resp_message'] = $message;
         $tpl->data['chal_resp_attributes'] = $attributes;
-        $tpl->data['errorcode'] = $errorCode;
+	}
+	if (isset($errorCode)) {
+		$tpl->data['errorcode'] = $errorCode;
 		$tpl->data['errorparams'] = $errorParams;
 	}
 	$tpl->data['forceUsername'] = TRUE;


### PR DESCRIPTION
The error code was only transmitted in case of challenge response.
This is fixed now.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/51?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/51'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>