### PR TITLE
Add multiple uid keys

### DIFF
--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -148,8 +148,10 @@ Use the following example:
 
         /**
          *  The uidKey is the username's attribute key.
+         *  You can choose a single one or multiple ones. The first set will be used.
          */
         'uidKey'            => 'uid',
+        //  'uidKey'        => array('uid', 'userName', 'uName'),
 
         /**
          *  Check if the hostname matches the name in the certificate (set to true or false)

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -34,7 +34,13 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
         $this->serverconfig['sslverifyhost'] = $cfg->getBoolean('sslverifyhost', null);
         $this->serverconfig['sslverifypeer'] = $cfg->getBoolean('sslverifypeer', null);
         $this->serverconfig['realm'] = $cfg->getString('realm', null);
-        $this->serverconfig['uidKey'] = $cfg->getString('uidKey', null);
+         try {
+             $this->serverconfig['uidKey'] = $cfg->getArray('uidKey');
+             SimpleSAML_Logger::debug("uidArray: try");
+         } catch (Exception $e) {
+             $this->serverconfig['uidKey'] = $cfg->getString('uidKey', null);
+             SimpleSAML_Logger::debug("uidArray: catch");
+         }
         $this->serverconfig['enabledPath'] = $cfg->getString('enabledPath', null);
         $this->serverconfig['enabledKey'] = $cfg->getString('enabledKey', null);
         $this->serverconfig['serviceAccount'] = $cfg->getString('serviceAccount', null);
@@ -57,6 +63,16 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 	     * If a configuration is not set in privacyidea:tokenEnrollment,
 	     * We are using the config from privacyidea:serverconfig.
 	     */
+
+        if (is_array($this->serverconfig['uidKey'])) {
+            foreach ($this->serverconfig['uidKey'] as $uidKey) {
+                SimpleSAML_Logger::debug("uidArray: " . $uidKey);
+                if (isset($state['Attributes'][$uidKey][0])){
+                    $this->serverconfig['uidKey'] = $uidKey;
+                    break;
+                }
+            }
+        }
 
 	    foreach ($this->serverconfig as $key => $value) {
 	    	if ($value === null) {

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -35,11 +35,9 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
         $this->serverconfig['sslverifypeer'] = $cfg->getBoolean('sslverifypeer', null);
         $this->serverconfig['realm'] = $cfg->getString('realm', null);
          try {
-             $this->serverconfig['uidKey'] = $cfg->getArray('uidKey');
-             SimpleSAML_Logger::debug("uidArray: try");
+             $this->serverconfig['uidKey'] = array($cfg->getString('uidKey'));
          } catch (Exception $e) {
-             $this->serverconfig['uidKey'] = $cfg->getString('uidKey', null);
-             SimpleSAML_Logger::debug("uidArray: catch");
+             $this->serverconfig['uidKey'] = $cfg->getArray('uidKey', null);
          }
         $this->serverconfig['enabledPath'] = $cfg->getString('enabledPath', null);
         $this->serverconfig['enabledKey'] = $cfg->getString('enabledKey', null);
@@ -64,10 +62,9 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 	     * We are using the config from privacyidea:serverconfig.
 	     */
 
-        if (is_array($this->serverconfig['uidKey'])) {
+	    if (!empty($this->serverconfig['uidKey'])) {
             foreach ($this->serverconfig['uidKey'] as $uidKey) {
-                SimpleSAML_Logger::debug("uidArray: " . $uidKey);
-                if (isset($state['Attributes'][$uidKey][0])){
+                if (isset($state['Attributes'][$uidKey][0])) {
                     $this->serverconfig['uidKey'] = $uidKey;
                     break;
                 }

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -22,10 +22,8 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 		$this->serverconfig['realm'] = $cfg->getString('realm', '');
 		try {
             	    $this->serverconfig['uidKey'] = $cfg->getArray('uidKey');
-            	    SimpleSAML_Logger::debug("uidArray: try");
         	} catch (Exception $e) {
-            	    $this->serverconfig['uidKey'] = $cfg->getString('uidKey', 'uid');
-            	    SimpleSAML_Logger::debug("uidArray: catch");
+            	    $this->serverconfig['uidKey'] = array($cfg->getString('uidKey', 'uid'));
         	}
 		$this->serverconfig['enabledPath'] = $cfg->getString('enabledPath', 'privacyIDEA');
 		$this->serverconfig['enabledKey'] = $cfg->getString('enabledKey', 'enabled');
@@ -37,15 +35,12 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 
 	public function process( &$state ) {
 
-	    if (is_array($this->serverconfig['uidKey'])) {
-                foreach ($this->serverconfig['uidKey'] as $uidKey) {
-                    SimpleSAML_Logger::debug("uidArray: " . $uidKey);
-                    if (isset($state['Attributes'][$uidKey][0])){
-                        $this->serverconfig['uidKey'] = $uidKey;
-                        break;
-                    }
-                }
-            }
+	    foreach ($this->serverconfig['uidKey'] as $uidKey) {
+	        if (isset($state['Attributes'][$uidKey][0])){
+	            $this->serverconfig['uidKey'] = $uidKey;
+	            break;
+	        }
+	    }
 
 	    foreach ( $this->serverconfig as $key => $value) {
 		$state['privacyidea:serverconfig'][$key] = $value;

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -21,12 +21,12 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 		$this->serverconfig['sslverifypeer'] = $cfg->getBoolean('sslverifypeer', true);
 		$this->serverconfig['realm'] = $cfg->getString('realm', '');
 		try {
-            $this->serverconfig['uidKey'] = $cfg->getArray('uidKey');
-            SimpleSAML_Logger::debug("uidArray: try");
-        } catch (Exception $e) {
-            $this->serverconfig['uidKey'] = $cfg->getString('uidKey', 'uid');
-            SimpleSAML_Logger::debug("uidArray: catch");
-        }
+            	    $this->serverconfig['uidKey'] = $cfg->getArray('uidKey');
+            	    SimpleSAML_Logger::debug("uidArray: try");
+        	} catch (Exception $e) {
+            	    $this->serverconfig['uidKey'] = $cfg->getString('uidKey', 'uid');
+            	    SimpleSAML_Logger::debug("uidArray: catch");
+        	}
 		$this->serverconfig['enabledPath'] = $cfg->getString('enabledPath', 'privacyIDEA');
 		$this->serverconfig['enabledKey'] = $cfg->getString('enabledKey', 'enabled');
 		$this->serverconfig['serviceAccount'] = $cfg->getString('serviceAccount', '');

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -38,17 +38,17 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 	public function process( &$state ) {
 
 	    if (is_array($this->serverconfig['uidKey'])) {
-            foreach ($this->serverconfig['uidKey'] as $uidKey) {
-                SimpleSAML_Logger::debug("uidArray: " . $uidKey);
-                if (isset($state['Attributes'][$uidKey][0])){
-                    $this->serverconfig['uidKey'] = $uidKey;
-                    break;
+                foreach ($this->serverconfig['uidKey'] as $uidKey) {
+                    SimpleSAML_Logger::debug("uidArray: " . $uidKey);
+                    if (isset($state['Attributes'][$uidKey][0])){
+                        $this->serverconfig['uidKey'] = $uidKey;
+                        break;
+                    }
                 }
             }
-        }
 
-		foreach ( $this->serverconfig as $key => $value) {
-			$state['privacyidea:serverconfig'][$key] = $value;
-		}
+	    foreach ( $this->serverconfig as $key => $value) {
+		$state['privacyidea:serverconfig'][$key] = $value;
+	    }
 	}
 }

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -20,7 +20,13 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 		$this->serverconfig['sslverifyhost'] = $cfg->getBoolean('sslverifyhost', true);
 		$this->serverconfig['sslverifypeer'] = $cfg->getBoolean('sslverifypeer', true);
 		$this->serverconfig['realm'] = $cfg->getString('realm', '');
-		$this->serverconfig['uidKey'] = $cfg->getString('uidKey', 'uid');
+		try {
+            $this->serverconfig['uidKey'] = $cfg->getArray('uidKey');
+            SimpleSAML_Logger::debug("uidArray: try");
+        } catch (Exception $e) {
+            $this->serverconfig['uidKey'] = $cfg->getString('uidKey', 'uid');
+            SimpleSAML_Logger::debug("uidArray: catch");
+        }
 		$this->serverconfig['enabledPath'] = $cfg->getString('enabledPath', 'privacyIDEA');
 		$this->serverconfig['enabledKey'] = $cfg->getString('enabledKey', 'enabled');
 		$this->serverconfig['serviceAccount'] = $cfg->getString('serviceAccount', '');
@@ -30,6 +36,16 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 	}
 
 	public function process( &$state ) {
+
+	    if (is_array($this->serverconfig['uidKey'])) {
+            foreach ($this->serverconfig['uidKey'] as $uidKey) {
+                SimpleSAML_Logger::debug("uidArray: " . $uidKey);
+                if (isset($state['Attributes'][$uidKey][0])){
+                    $this->serverconfig['uidKey'] = $uidKey;
+                    break;
+                }
+            }
+        }
 
 		foreach ( $this->serverconfig as $key => $value) {
 			$state['privacyidea:serverconfig'][$key] = $value;


### PR DESCRIPTION
This makes it possible to use either one or more uid keys. The first set one will be used.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/55%23discussion_r252265727%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/55%23discussion_r252267102%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/55%23discussion_r252267651%22%2C%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/55%23discussion_r252285150%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20834e3742c3732ea59b84304176fbd650c53eac8a%20lib/Auth/Process/privacyidea.php%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/privacyidea/simplesamlphp-module-privacyidea/pull/55%23discussion_r252265727%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Wouldn%27t%20it%20be%20more%20elegant%20to%20always%20write%20to%20an%20array%3F%5Cr%5CnSo%20if%20this%20is%20a%20string%2C%20simple%20write%20an%20array%20with%20one%20element.%5Cr%5CnThen%20the%20program%20code%20further%20below%20does%20not%20need%20to%20check%20%60%60is_array%60%60%2C%20it%20gets%20a%20bit%20simple%2C%20since%20it%20will%20always%20use%20uidKey%5B0%5D.%22%2C%20%22created_at%22%3A%20%222019-01-30T13%3A57%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20it%20would%20be%2C%20but%20it%20should%20be%20backward%20compatible%2C%20shouldn%27t%20it%3F%5Cr%5CnIf%20we%20do%20it%20always%20as%20an%20array%2C%20the%20old%20configuration%20will%20not%20work%20after%20the%20update..%22%2C%20%22created_at%22%3A%20%222019-01-30T14%3A01%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/35998229%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Mipronimo%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20misunderstood.%20Of%20course%20the%20config%20file%20itself%20can%20contain%20a%20string%20like%5Cr%5Cn%5Cr%5Cn%7E%7E%7E%7Ephp%5Cr%5Cn%20%20%20%20%27uidKey%27%20%3D%3E%20%27uid%27%2C%5Cr%5Cn%7E%7E%7E%7E%5Cr%5CnBut%20the%20config%20loading%20code%20should%20load%20this%20config%20as%20array%2C%20so%20that%20we%20internally%20always%20treat%20this%20config%20as%20array.%22%2C%20%22created_at%22%3A%20%222019-01-30T14%3A02%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/1908620%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cornelinux%22%7D%7D%2C%20%7B%22body%22%3A%20%22please%20have%20a%20look%20at%2084f1c82%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222019-01-30T14%3A44%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/35998229%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Mipronimo%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/Auth/Process/privacyidea.php%3AL34-47%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 834e3742c3732ea59b84304176fbd650c53eac8a lib/Auth/Process/privacyidea.php 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/55#discussion_r252265727'>File: lib/Auth/Process/privacyidea.php:L34-47</a></b>
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> Wouldn't it be more elegant to always write to an array?
So if this is a string, simple write an array with one element.
Then the program code further below does not need to check ``is_array``, it gets a bit simple, since it will always use uidKey[0].
- <a href='https://github.com/Mipronimo'><img border=0 src='https://avatars1.githubusercontent.com/u/35998229?v=4' height=16 width=16></a> Yes, it would be, but it should be backward compatible, shouldn't it?
If we do it always as an array, the old configuration will not work after the update..
- <a href='https://github.com/cornelinux'><img border=0 src='https://avatars1.githubusercontent.com/u/1908620?v=4' height=16 width=16></a> You misunderstood. Of course the config file itself can contain a string like
~~~~php
'uidKey' => 'uid',
~~~~
But the config loading code should load this config as array, so that we internally always treat this config as array.
- <a href='https://github.com/Mipronimo'><img border=0 src='https://avatars1.githubusercontent.com/u/35998229?v=4' height=16 width=16></a> please have a look at 84f1c82


<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/55?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/55?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/55'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>