### PR TITLE
added pass on no token

### DIFF
--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -176,8 +176,15 @@ Use the following example:
         /**
          *  You can enable or disable trigger challenge
          */
-        'doTriggerChallenge' => true
-        
+        'doTriggerChallenge' => true,
+
+        /**
+         *  If the user has no token, he can be passed directly
+         *  privacyidea:tokenEnrollment has to be turned off!
+         *  doTriggerChallenge has to be turned on and configured correctly
+         */
+         'passOnNoToken'    => true,
+
         /**
          *  Other authproc filters can disable 2FA if you want to.
          *  If privacyIDEA should listen to the setting, you have to enter the state's path and key.

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -44,6 +44,7 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
         $this->serverconfig['serviceAccount'] = $cfg->getString('serviceAccount', null);
 	    $this->serverconfig['servicePass'] = $cfg->getString('servicePass', null);
 	    $this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', null);
+	    $this->serverconfig['passOnNoToken'] = $cfg->getBoolean('passOnNoToken', null);
      }
 
     /**
@@ -106,6 +107,17 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 					"authorization:" . $authToken,
 				);
 				$body = sspmod_privacyidea_Auth_utils::curl($params, $headers, $this->serverconfig, "/validate/triggerchallenge", "POST");
+				if ($this->serverconfig['passOnNoToken']) {
+					try {
+						$result = $body->result;
+						$value = $result->value;
+					} catch (Exception $e) {
+						throw new SimpleSAML_Error_BadRequest("privacyIDEA: We were not able to read the response from the PI server");
+					}
+					if ($value === 0) {
+						return;
+					}
+				}
 				try {
 					$detail = $body->detail;
 					$multi_challenge = $detail->multi_challenge;

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -30,6 +30,7 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 		$this->serverconfig['serviceAccount'] = $cfg->getString('serviceAccount', '');
 		$this->serverconfig['servicePass'] = $cfg->getString('servicePass', '');
 		$this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', false);
+		$this->serverconfig['passOnNoToken'] = $cfg->getBoolean('passOnNoToken', false);
 
 	}
 


### PR DESCRIPTION
A user can no pass the second step, if he has no token.
Triggerchallenge must be enabled and token enrollment disabled.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/57?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/57'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>