### PR TITLE
add pass on no token

### DIFF
--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -195,6 +195,12 @@ Use the following example:
          */
 
         'tryFirstAuthentication' => true,
+
+        /**
+         *  You can decide, which password should be used for tryFirstAuthentication
+         */
+
+         'tryFirstAuthPass' => 'simpleSAMLphp',
     ),
 
     /**

--- a/docs/privacyidea.txt
+++ b/docs/privacyidea.txt
@@ -176,7 +176,7 @@ Use the following example:
         /**
          *  You can enable or disable trigger challenge
          */
-        'doTriggerChallenge' => true
+        'doTriggerChallenge' => true,
         
         /**
          *  Other authproc filters can disable 2FA if you want to.
@@ -187,6 +187,14 @@ Use the following example:
          */
         'enabledPath'       => '',
         'enabledKey'        => '',
+
+        /**
+         *  If you want to use passOnNoToken or passOnNoUser, you can decide, if this module should send a password to
+         *  privacyIDEA. If passOnNoToken is activated and the user does not have a token, he will be passed by privacyIDEA.
+         *  NOTE: Do not use it with privacyidea:tokenEnrollment.
+         */
+
+        'tryFirstAuthentication' => true,
     ),
 
     /**

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -44,6 +44,7 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
         $this->serverconfig['serviceAccount'] = $cfg->getString('serviceAccount', null);
 	    $this->serverconfig['servicePass'] = $cfg->getString('servicePass', null);
 	    $this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', null);
+	    $this->serverconfig['tryFirstAuthentication'] = $cfg->getBoolean('tryFirstAuthentication', null);
      }
 
     /**
@@ -97,6 +98,15 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 		}
 
 		if($piEnabled) {
+			if ($this->serverconfig['tryFirstAuthentication']) {
+				try {
+					if ($this->authenticate($state, "simpleSAMLphp", null, null, null, null)) {
+						return;
+					}
+				} catch (SimpleSAML_Error_Error $e) {
+					SimpleSAML_Logger::debug("privacyIDEA: user has token");
+				}
+			}
 			if ($this->serverconfig['doTriggerChallenge']) {
 				$authToken = sspmod_privacyidea_Auth_utils::fetchAuthToken($this->serverconfig);
 				$params = array(

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -45,6 +45,7 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 	    $this->serverconfig['servicePass'] = $cfg->getString('servicePass', null);
 	    $this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', null);
 	    $this->serverconfig['tryFirstAuthentication'] = $cfg->getBoolean('tryFirstAuthentication', null);
+	    $this->serverconfig['tryFirstAuthPass'] = $cfg->getString('tryFirstAuthPass', null);
      }
 
     /**
@@ -100,7 +101,7 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 		if($piEnabled) {
 			if ($this->serverconfig['tryFirstAuthentication']) {
 				try {
-					if ($this->authenticate($state, "simpleSAMLphp", null, null, null, null)) {
+					if ($this->authenticate($state, $this->serverconfig['tryFirstAuthPass'], null, null, null, null)) {
 						return;
 					}
 				} catch (SimpleSAML_Error_Error $e) {

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -30,6 +30,7 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 		$this->serverconfig['serviceAccount'] = $cfg->getString('serviceAccount', '');
 		$this->serverconfig['servicePass'] = $cfg->getString('servicePass', '');
 		$this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', false);
+		$this->serverconfig['tryFirstAuthentication'] = $cfg->getBoolean('tryFirstAuthentication', false);
 
 	}
 

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -31,6 +31,7 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 		$this->serverconfig['servicePass'] = $cfg->getString('servicePass', '');
 		$this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', false);
 		$this->serverconfig['tryFirstAuthentication'] = $cfg->getBoolean('tryFirstAuthentication', false);
+		$this->serverconfig['tryFirstAuthPass'] = $cfg->getString('tryFirstAuthPass', 'simpleSAMLphp');
 
 	}
 


### PR DESCRIPTION
Now this plugin can try to authenticate before the user could enter a password.
If this is successful, the user will be passed without entering the otp.
closes #41
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/privacyidea/simplesamlphp-module-privacyidea/pull/58?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/privacyidea/simplesamlphp-module-privacyidea/pull/58'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>