### PR TITLE
Skip other sites if the user has already completed 2FA

### DIFF
--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -130,7 +130,7 @@ Use the following example:
 'authproc' => array(
 
     /**
-     *  The first authproc filter conatins the configuration for the privacyIDEA server.
+     *  The first authproc filter contains the configuration for the privacyIDEA server.
      */
     20 => array(
         'class'             => 'privacyidea:serverconfig',
@@ -176,11 +176,16 @@ Use the following example:
          *  You can enable or disable trigger challenge
          */
         'doTriggerChallenge' => true,
-        
+
+        /**
+         *  You can enable the ability for privacyidea to be disabled if the user has already passed 2FA on another related site and their session hasn't expired.
+         */
+        'skipforothersites' => 'yes',
+                
         /**
          *  Other authproc filters can disable 2FA if you want to.
          *  If privacyIDEA should listen to the setting, you have to enter the state's path and key.
-         *  The value of this key will be set by a previous auth proc filger.
+         *  The value of this key will be set by a previous auth proc filter.
          *  privacyIDEA will only be disabled, if the value of the key is set to false,
          *  in any other situation (e.g. the key is not set or does not exist), privacyIDEA will be enabled.
          */

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -46,6 +46,7 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 	    $this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', null);
 	    $this->serverconfig['tryFirstAuthentication'] = $cfg->getBoolean('tryFirstAuthentication', null);
 	    $this->serverconfig['tryFirstAuthPass'] = $cfg->getString('tryFirstAuthPass', null);
+	    $this->serverconfig['skipforothersites'] = $cfg->getString('skipforothersites', null);
      }
 
     /**
@@ -85,6 +86,7 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 		    'sslverifypeer' => $this->serverconfig['sslverifypeer'],
 		    'realm' => $this->serverconfig['realm'],
 		    'uidKey' => $this->serverconfig['uidKey'],
+		    'skipforothersites' => $this->serverconfig['skipforothersites'],
 	    );
 
     	if(isset($state[$this->serverconfig['enabledPath']][$this->serverconfig['enabledKey']][0])) {
@@ -97,7 +99,9 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 			$piEnabled = False;
 			SimpleSAML_Logger::error("privacyIDEA url is not set!");
 		}
-
+    if ($this->serverconfig['skipforothersites'] === 'yes' && $state["Expire"] > time()) {
+        $piEnabled = False;
+    }
 		if($piEnabled) {
 			if ($this->serverconfig['tryFirstAuthentication']) {
 				try {

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -32,6 +32,7 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 		$this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', false);
 		$this->serverconfig['tryFirstAuthentication'] = $cfg->getBoolean('tryFirstAuthentication', false);
 		$this->serverconfig['tryFirstAuthPass'] = $cfg->getString('tryFirstAuthPass', 'simpleSAMLphp');
+    $this->serverconfig['skipforothersites'] = $cfg->getString('skipforothersites', null);
 
 	}
 


### PR DESCRIPTION
Hi,

I couldn't figure out a way to stop privacyidea from doing 2FA when using the authproc method or "Method 2" when you are going between different sites. So, you login to site one, then do the 2FA, and then visit site two and it asks you to do the 2FA again.

Since, I couldn't figure out a way to do this, feel free to correct me if I'm wrong about this, I created a configuration option and some code.