### PR TITLE
checkEntityID authproc filter with regexp matching and fallback to 2FA enabled

### DIFF
--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -223,7 +223,7 @@ Use the following example:
     22 => array(
         'class'                => 'privacyidea:checkEntityID',
         /**
-         *  Depending on setFalseEntityIDs and setTrueAttributes the filter will set the state variable 
+         *  Depending on excludeEntityIDs and includeAttributes the filter will set the state variable 
          *  $state[$setPath][$setPath] to true or false.
          *  To selectively enable or disable privacyIDEA, make sure that you specify setPath and setKey such
          *  that they equal enabledPath and enabledKey from privacyidea:serverconfig or privacyidea:privacyidea.
@@ -235,19 +235,19 @@ Use the following example:
          *  If there is a match, the filter will set the specified state variable to false and thereby disables 
          *  privacyIDEA for this entityID The first matching expression will take precedence.
          */
-        'setFalseEntityIDs' => array(
+        'excludeEntityIDs' => array(
             '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/',
             '/http(.*)no2fa-provider.de/'
         ),
         /**
-         *  Per value in setFalseEntityIDs, you may specify another set of regular expressions to match the 
+         *  Per value in excludeEntityIDs, you may specify another set of regular expressions to match the 
          *  attributes in the SAML request. If there is a match in any attribute value, this filter will 
          *  set the state variable to true and thereby enable privacyIDEA where it would be normally disabled
          *  due to the matching entityID. This may be used to enable 2FA at this entityID only for privileged
          *  accounts.
-         *  The key in setTrueAttributes must be identical to a value in setFalseEntityIDs to have an effect!
+         *  The key in includeAttributes must be identical to a value in excludeEntityIDs to have an effect!
          */
-        'setTrueAttributes' => array(
+        'includeAttributes' => array(
             '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/' => array(
                 'memberOf' => array(
                     '/cn=2fa-required([-_])regexmatch(.*),cn=groups,(.*)/',

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -223,7 +223,7 @@ Use the following example:
     22 => array(
         'class'                => 'privacyidea:checkEntityID',
         /**
-         *  Depending on entityids and excludeattributes the filter will set the state variable 
+         *  Depending on setFalseEntityIDs and setTrueAttributes the filter will set the state variable 
          *  $state[$setPath][$setPath] to true or false.
          *  To selectively enable or disable privacyIDEA, make sure that you specify setPath and setKey such
          *  that they equal enabledPath and enabledKey from privacyidea:serverconfig or privacyidea:privacyidea.
@@ -232,31 +232,33 @@ Use the following example:
         'setKey'               => 'enabled',
         /**
          *  The requesting SAML provider's entityID will be tested against this list of regular expressions.
-         *  If there is a match, the filter will set the specified state variable to false. The first matching 
-         *  expression will take precedence.
+         *  If there is a match, the filter will set the specified state variable to false and thereby disables 
+         *  privacyIDEA for this entityID The first matching expression will take precedence.
          */
-        'entityids'            => array(
-                                      '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/',
-                                      '/http(.*)no2fa-provider.de/'
-                                  ),
-        /**
-         *  Per value in entityids, you may specify another set of regular expressions to match the 
-         *  attributes in the SAML request. If there is a match in any attribute value, this filter will 
-         *  set the state variable to true.
-         *  The key in excludeattributes must be identical to a value in entityids to have an effect!
-         */
-        'excludeattributes'    => array(
-                                      '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/' => array(
-                                          'memberOf' => array(
-                                              '/cn=2fa-required([-_])regexmatch(.*),cn=groups,(.*)/',
-                                              'cn=2fa-required-exactmatch,ou=section,dc=privacyidea,dc=org'
-                                          ),
-                                          'myAttribute' => array(
-                                              '/(.*)2fa-required/', '2fa-required',
-                                          )
-                                      )
-                                  )
+        'setFalseEntityIDs' => array(
+            '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/',
+            '/http(.*)no2fa-provider.de/'
         ),
+        /**
+         *  Per value in setFalseEntityIDs, you may specify another set of regular expressions to match the 
+         *  attributes in the SAML request. If there is a match in any attribute value, this filter will 
+         *  set the state variable to true and thereby enable privacyIDEA where it would be normally disabled
+         *  due to the matching entityID. This may be used to enable 2FA at this entityID only for privileged
+         *  accounts.
+         *  The key in setTrueAttributes must be identical to a value in setFalseEntityIDs to have an effect!
+         */
+        'setTrueAttributes' => array(
+            '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/' => array(
+                'memberOf' => array(
+                    '/cn=2fa-required([-_])regexmatch(.*),cn=groups,(.*)/',
+                    'cn=2fa-required-exactmatch,ou=section,dc=privacyidea,dc=org'
+                ),
+                'myAttribute' => array(
+                    '/(.*)2fa-required/', '2fa-required',
+                )
+            )
+        )
+    ),
 
     /**
      *  This filter is optional. You can enable it, if you want to enroll tokens for users, who do not have one yet.
@@ -291,5 +293,6 @@ Use the following example:
          *  'serviceAccount' => 'service',
          *  'servicePass' => 'service',
          */
-),
+    ),
+)
 ```

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -217,6 +217,48 @@ Use the following example:
     ),
 
     /**
+     *  This filter is optional. If you want to selectively disable the privacyIDEA authentication using the
+     *  the entityID and/or SAML attributes, you may enable this filter
+     */
+    22 => array(
+        'class'                => 'privacyidea:checkEntityID',
+        /**
+         *  Depending on entityids and excludeattributes the filter will set the state variable 
+         *  $state[$setPath][$setPath] to true or false.
+         *  To selectively enable or disable privacyIDEA, make sure that you specify setPath and setKey such
+         *  that they equal enabledPath and enabledKey from privacyidea:serverconfig or privacyidea:privacyidea.
+         */
+        'setPath'              => 'privacyIDEA',
+        'setKey'               => 'enabled',
+        /**
+         *  The requesting SAML provider's entityID will be tested against this list of regular expressions.
+         *  If there is a match, the filter will set the specified state variable to false. The first matching 
+         *  expression will take precedence.
+         */
+        'entityids'            => array(
+                                      '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/',
+                                      '/http(.*)no2fa-provider.de/'
+                                  ),
+        /**
+         *  Per value in entityids, you may specify another set of regular expressions to match the 
+         *  attributes in the SAML request. If there is a match in any attribute value, this filter will 
+         *  set the state variable to true.
+         *  The key in excludeattributes must be identical to a value in entityids to have an effect!
+         */
+        'excludeattributes'    => array(
+                                      '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/' => array(
+                                          'memberOf' => array(
+                                              '/cn=2fa-required([-_])regexmatch(.*),cn=groups,(.*)/',
+                                              'cn=2fa-required-exactmatch,ou=section,dc=privacyidea,dc=org'
+                                          ),
+                                          'myAttribute' => array(
+                                              '/(.*)2fa-required/', '2fa-required',
+                                          )
+                                      )
+                                  )
+        ),
+
+    /**
      *  This filter is optional. You can enable it, if you want to enroll tokens for users, who do not have one yet.
      */
     24 => array(

--- a/lib/Auth/Process/checkEntityID.php
+++ b/lib/Auth/Process/checkEntityID.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This Auth Proc Filter allows the selective deactivation of privacyIDEA for a list of regular expressions
+ * which match SAML service provider entityIDs.
+ * The filter checks the entityid in the SAML request against a list of regular expressions and sets the state variable
+ * $state[enabledPath][enabledKey][0] to false on match, which can be used to disable privacyIDEA.
+ * For any value in entityids, the config parameter excludeattributes may be used to enable privacyIDEA for a subset
+ * of users which have these attribute values (e.g. memberOf).
+ * @author Henning Hollermann <henning.hollermann@netknights.it>
+ */
+
+class sspmod_privacyIDEA_Auth_Process_checkEntityID extends SimpleSAML_Auth_ProcessingFilter {
+
+    private $entityids = array();
+    private $excludeattributes = array();
+    private $setPath = '';
+    private $setKey = '';
+
+    private function str_matches_reg_arr($str, $reg_arr) {
+        /*
+         * This function checks a given string against an array with regular expressions
+         * It will return true if a match is found.
+         */
+        $ret_arr = array();
+        foreach ($reg_arr as $reg) {
+            if ($reg[0] != "/") {
+                $reg = "/" . $reg . "/";
+            }
+            SimpleSAML_Logger::debug("privacyidea:checkEntityID: test regexp " . $reg .
+                " against the string " . $str);
+            if (preg_match($reg, $str)) {
+                array_push($ret_arr, $reg);
+            }
+        }
+        return $ret_arr;
+    }
+
+    public function __construct(array $config, $reserved)
+    {
+        SimpleSAML_Logger::info("Checking requesting entity ID for privacyIDEA");
+        parent::__construct($config, $reserved);
+        $cfg = SimpleSAML_Configuration::loadFromArray($config, 'privacyidea:checkEntityID');
+        $this->entityids = $cfg->getArray('entityids', null);
+        $this->excludeattributes = $cfg->getArray('excludeattributes', null);
+        $this->setPath = $cfg->getString('setPath', null);
+        $this->setKey = $cfg->getString('setKey', null);
+
+    }
+
+    public function process( &$state ) {
+        // the default return value is true, privacyIDEA should be enabled by default.
+        $ret = true;
+        $request_entityid = $state["Destination"]["entityid"];
+        // if the requesting entityid matches the given list set the return parameter to false
+        SimpleSAML_Logger::debug("privacyidea:checkEntityID: Requesting entityID is " . $request_entityid);
+        $matched_entityids = $this->str_matches_reg_arr($request_entityid, $this->entityids);
+        if ($matched_entityids) {
+            $ret = false;
+            $entityid_key = $matched_entityids[0];
+            SimpleSAML_Logger::debug("privacyidea:checkEntityID: Matched entityID is " . $entityid_key);
+            // if there is also a match for any attribute value in the excludeattributes
+            // fall back to the default return value: true
+            if (isset($this->excludeattributes[$entityid_key])) {
+                foreach ($this->excludeattributes[$entityid_key] as $attr_key => $attr_regexp_arr) {
+                    if (isset($state["Attributes"][$attr_key])) {
+                        foreach($state["Attributes"][$attr_key] as $attr_val) {
+                            $matched_attrs = $this->str_matches_reg_arr($attr_val, $attr_regexp_arr);
+                            if (!empty($matched_attrs)) {
+                                $ret = true;
+                                SimpleSAML_Logger::error("privacyidea:checkEntityID: Requesting entityID in " .
+                                    "list, but excluded by at least one attribute regexp \"" .$attr_key.
+                                    "\" = \"" . $matched_attrs[0]. "\".");
+                                break;
+                            }
+                        }
+                    } else {
+                        SimpleSAML_Logger::debug("privacyidea:checkEntityID: attribute key " .
+                            $attr_key . " not contained in request");
+                    }
+                }
+            }
+        } else {
+            SimpleSAML_Logger::debug("privacyidea:checkEntityID: Requesting entityID " .
+                $request_entityid ." not matched by any regexp.");
+        }
+        $state[$this->setPath][$this->setKey][0] = $ret;
+        if ($ret) {$ret_str = "true";} else {$ret_str = "false";}
+        SimpleSAML_Logger::debug("Setting \$state[" . $this->setPath. "][".$this->setKey."][0] = ".$ret_str.".");
+    }
+
+}

--- a/lib/Auth/Process/checkEntityID.php
+++ b/lib/Auth/Process/checkEntityID.php
@@ -4,15 +4,15 @@
  * which match SAML service provider entityIDs.
  * The filter checks the entityid in the SAML request against a list of regular expressions and sets the state variable
  * $state[enabledPath][enabledKey][0] to false on match, which can be used to disable privacyIDEA.
- * For any value in entityids, the config parameter excludeattributes may be used to enable privacyIDEA for a subset
+ * For any value in setFalseEntityIDs, the config parameter setTrueAttributes may be used to enable privacyIDEA for a subset
  * of users which have these attribute values (e.g. memberOf).
  * @author Henning Hollermann <henning.hollermann@netknights.it>
  */
 
 class sspmod_privacyIDEA_Auth_Process_checkEntityID extends SimpleSAML_Auth_ProcessingFilter {
 
-    private $entityids = array();
-    private $excludeattributes = array();
+    private $setFalseEntityIDs = array();
+    private $setTrueAttributes = array();
     private $setPath = '';
     private $setKey = '';
 
@@ -40,8 +40,8 @@ class sspmod_privacyIDEA_Auth_Process_checkEntityID extends SimpleSAML_Auth_Proc
         SimpleSAML_Logger::info("Checking requesting entity ID for privacyIDEA");
         parent::__construct($config, $reserved);
         $cfg = SimpleSAML_Configuration::loadFromArray($config, 'privacyidea:checkEntityID');
-        $this->entityids = $cfg->getArray('entityids', null);
-        $this->excludeattributes = $cfg->getArray('excludeattributes', null);
+        $this->setFalseEntityIDs = $cfg->getArray('setFalseEntityIDs', null);
+        $this->setTrueAttributes = $cfg->getArray('setTrueAttributes', null);
         $this->setPath = $cfg->getString('setPath', null);
         $this->setKey = $cfg->getString('setKey', null);
 
@@ -53,15 +53,15 @@ class sspmod_privacyIDEA_Auth_Process_checkEntityID extends SimpleSAML_Auth_Proc
         $request_entityid = $state["Destination"]["entityid"];
         // if the requesting entityid matches the given list set the return parameter to false
         SimpleSAML_Logger::debug("privacyidea:checkEntityID: Requesting entityID is " . $request_entityid);
-        $matched_entityids = $this->str_matches_reg_arr($request_entityid, $this->entityids);
+        $matched_entityids = $this->str_matches_reg_arr($request_entityid, $this->setFalseEntityIDs);
         if ($matched_entityids) {
             $ret = false;
             $entityid_key = $matched_entityids[0];
             SimpleSAML_Logger::debug("privacyidea:checkEntityID: Matched entityID is " . $entityid_key);
-            // if there is also a match for any attribute value in the excludeattributes
+            // if there is also a match for any attribute value in the setTrueAttributes
             // fall back to the default return value: true
-            if (isset($this->excludeattributes[$entityid_key])) {
-                foreach ($this->excludeattributes[$entityid_key] as $attr_key => $attr_regexp_arr) {
+            if (isset($this->setTrueAttributes[$entityid_key])) {
+                foreach ($this->setTrueAttributes[$entityid_key] as $attr_key => $attr_regexp_arr) {
                     if (isset($state["Attributes"][$attr_key])) {
                         foreach($state["Attributes"][$attr_key] as $attr_val) {
                             $matched_attrs = $this->str_matches_reg_arr($attr_val, $attr_regexp_arr);

--- a/lib/Auth/Process/checkEntityID.php
+++ b/lib/Auth/Process/checkEntityID.php
@@ -19,7 +19,7 @@ class sspmod_privacyIDEA_Auth_Process_checkEntityID extends SimpleSAML_Auth_Proc
     private function str_matches_reg_arr($str, $reg_arr) {
         /*
          * This function checks a given string against an array with regular expressions
-         * It will return true if a match is found.
+         * It will return an array with matches.
          */
         $ret_arr = array();
         foreach ($reg_arr as $reg) {

--- a/lib/Auth/Process/checkEntityID.php
+++ b/lib/Auth/Process/checkEntityID.php
@@ -4,15 +4,15 @@
  * which match SAML service provider entityIDs.
  * The filter checks the entityid in the SAML request against a list of regular expressions and sets the state variable
  * $state[enabledPath][enabledKey][0] to false on match, which can be used to disable privacyIDEA.
- * For any value in setFalseEntityIDs, the config parameter setTrueAttributes may be used to enable privacyIDEA for a subset
+ * For any value in excludeEntityIDs, the config parameter includeAttributes may be used to enable privacyIDEA for a subset
  * of users which have these attribute values (e.g. memberOf).
  * @author Henning Hollermann <henning.hollermann@netknights.it>
  */
 
 class sspmod_privacyIDEA_Auth_Process_checkEntityID extends SimpleSAML_Auth_ProcessingFilter {
 
-    private $setFalseEntityIDs = array();
-    private $setTrueAttributes = array();
+    private $excludeEntityIDs = array();
+    private $includeAttributes = array();
     private $setPath = '';
     private $setKey = '';
 
@@ -40,8 +40,8 @@ class sspmod_privacyIDEA_Auth_Process_checkEntityID extends SimpleSAML_Auth_Proc
         SimpleSAML_Logger::info("Checking requesting entity ID for privacyIDEA");
         parent::__construct($config, $reserved);
         $cfg = SimpleSAML_Configuration::loadFromArray($config, 'privacyidea:checkEntityID');
-        $this->setFalseEntityIDs = $cfg->getArray('setFalseEntityIDs', null);
-        $this->setTrueAttributes = $cfg->getArray('setTrueAttributes', null);
+        $this->excludeEntityIDs = $cfg->getArray('excludeEntityIDs', null);
+        $this->includeAttributes = $cfg->getArray('includeAttributes', null);
         $this->setPath = $cfg->getString('setPath', null);
         $this->setKey = $cfg->getString('setKey', null);
 
@@ -53,15 +53,15 @@ class sspmod_privacyIDEA_Auth_Process_checkEntityID extends SimpleSAML_Auth_Proc
         $request_entityid = $state["Destination"]["entityid"];
         // if the requesting entityid matches the given list set the return parameter to false
         SimpleSAML_Logger::debug("privacyidea:checkEntityID: Requesting entityID is " . $request_entityid);
-        $matched_entityids = $this->str_matches_reg_arr($request_entityid, $this->setFalseEntityIDs);
+        $matched_entityids = $this->str_matches_reg_arr($request_entityid, $this->excludeEntityIDs);
         if ($matched_entityids) {
             $ret = false;
             $entityid_key = $matched_entityids[0];
             SimpleSAML_Logger::debug("privacyidea:checkEntityID: Matched entityID is " . $entityid_key);
-            // if there is also a match for any attribute value in the setTrueAttributes
+            // if there is also a match for any attribute value in the includeAttributes
             // fall back to the default return value: true
-            if (isset($this->setTrueAttributes[$entityid_key])) {
-                foreach ($this->setTrueAttributes[$entityid_key] as $attr_key => $attr_regexp_arr) {
+            if (isset($this->includeAttributes[$entityid_key])) {
+                foreach ($this->includeAttributes[$entityid_key] as $attr_key => $attr_regexp_arr) {
                     if (isset($state["Attributes"][$attr_key])) {
                         foreach($state["Attributes"][$attr_key] as $attr_val) {
                             $matched_attrs = $this->str_matches_reg_arr($attr_val, $attr_regexp_arr);


### PR DESCRIPTION
closes #88

Compared to #87 
- removed the onmatch setting to always fallback to 2FA enabled if there is no match.
- a match with the regular expressions in "excludeattributes" sets the state variable to true, which will enable privacyIDEA although it should be disabled by entityid (therefore the name "exclude")
- use regular expression matching instead of exact matching
- useful debug messages