### PR TITLE
Fix passive requests in auth proc filter.

### DIFF
--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -62,6 +62,14 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
             );
             return;
         }
+
+        if (isset($state['isPassive']) && $state['isPassive'] === true) {
+            if (SimpleSAML_Session::getSessionFromRequest()->getData('privacyidea:privacyidea', 'authenticated')) {
+                SimpleSAML_Logger::debug("privacyIDEA: ignore passive SAML request for already logged in user");
+                return;
+            }
+            throw new \SimpleSAML\Module\saml\Error\NoPassive('Passive authentication (OTP) not supported.');
+        }
         if (!$this->serverconfig['privacyideaserver']) {SimpleSAML_Logger::error("privacyIDEA url is not set!");}
         if ($this->maybeTryFirstAuthentication($state)) {return;}
         if ($this->serverconfig['doTriggerChallenge']) {$state = $this->triggerChallenge($state);}

--- a/www/otpform.php
+++ b/www/otpform.php
@@ -63,6 +63,8 @@
                         "regdata" => $registrationData
                     )
                 )) {
+					$session = SimpleSAML_Session::getSessionFromRequest();
+					$session->setData('privacyidea:privacyidea', 'authenticated', true);
 					SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea:init');
                     SimpleSAML_Logger::debug("Saved state privacyidea:privacyidea:init from otpform.php");
 					SimpleSAML_Auth_ProcessingChain::resumeProcessing($state);
@@ -70,7 +72,7 @@
 					SimpleSAML_Logger::debug("privacyIDEA: User entered wrong OTP");
 				}
 			} elseif ($state['privacyidea:privacyidea:authenticationMethod'] === "authsource") {
-				if (sspmod_privacyidea_Auth_Source_privacyidea::handleLogin($authStateId, $username, $password, $transaction_id, $signatureData, $clientData));
+				sspmod_privacyidea_Auth_Source_privacyidea::handleLogin($authStateId, $username, $password, $transaction_id, $signatureData, $clientData);
 			}
         } catch (SimpleSAML_Error_Error $e) {
             /* Login failed. Extract error code and parameters, to display the error. */


### PR DESCRIPTION
When a passive SAML request (`<samlp:AuthnRequest IsPassive="true">`) is received a `urn:oasis:names:tc:SAML:2.0:status:NoPassive` status error is expected (instead of a login form).

The privacyidea plugin must not ask for a OTP in this case.
As a auth proc filter is executed after being authenticated we have to store that also the OTP authentication succeeded in the session (otherwise one can bypass OTP check (with passive requests, which are e.g. used by
Univention Corporate Server's Management Console) while one is not logged in)