### PR TITLE
set defaults to supress warnings about missing keys

### DIFF
--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -30,6 +30,8 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 
         parent::__construct($config, $reserved);
         $this->serverconfig = $config;
+        if (!isset($this->serverconfig['tryFirstAuthentication'])) { $this->serverconfig['tryFirstAuthentication'] = false; }
+        if (!isset($this->serverconfig['doTriggerChallenge'])) { $this->serverconfig['doTriggerChallenge'] = false; }
     }
 
     /**


### PR DESCRIPTION
This PR supresses warnings about missing keys in serverconfig by setting the according values if they are not present in the configuration file.