### PR TITLE
95/support sso

### DIFF
--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -177,6 +177,13 @@ Use the following example:
         'servicePass'       => 'service',
 
         /**
+         *  Specify if you would like to enable SSO for privacyIDEA. If set to false, the user
+         *  will be prompted for the second factor at every new service provider he/she visits. 
+         *  Defaults to true.
+         */
+        'SSO'              => true,
+         
+        /**
          *  You can enable or disable trigger challenge
          */
         'doTriggerChallenge' => true,

--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -95,14 +95,14 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
          */
         if (isset($state['isPassive']) && $state['isPassive'] === true) {
             if (isset($state["Expire"]) && $state["Expire"] > time()) {
-                SimpleSAML_Logger::error("privacyIDEA: ignoring passive SAML request for already logged in user");
+                SimpleSAML_Logger::debug("privacyIDEA: ignoring passive SAML request for already logged in user");
                 return;
             }
             throw new \SimpleSAML\Module\saml\Error\NoPassive('Passive authentication (OTP) not supported.');
         }
         if (isset($this->serverconfig['SSO']) && $this->serverconfig['SSO'] === true) {
             if (isset($state["Expire"]) && $state["Expire"] > time()) {
-                SimpleSAML_Logger::error("privacyIDEA: SSO is enabled. Ignoring SAML request for already logged in user.");
+                SimpleSAML_Logger::debug("privacyIDEA: SSO is enabled. Ignoring SAML request for already logged in user.");
                 return;
             }
         }

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -32,7 +32,7 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 		$this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', false);
 		$this->serverconfig['tryFirstAuthentication'] = $cfg->getBoolean('tryFirstAuthentication', false);
 		$this->serverconfig['tryFirstAuthPass'] = $cfg->getString('tryFirstAuthPass', 'simpleSAMLphp');
-        $this->serverconfig['SSO'] = $cfg->getBoolean('SSO', true);
+		$this->serverconfig['SSO'] = $cfg->getBoolean('SSO', true);
 
 	}
 

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -32,6 +32,7 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 		$this->serverconfig['doTriggerChallenge'] = $cfg->getBoolean('doTriggerChallenge', false);
 		$this->serverconfig['tryFirstAuthentication'] = $cfg->getBoolean('tryFirstAuthentication', false);
 		$this->serverconfig['tryFirstAuthPass'] = $cfg->getString('tryFirstAuthPass', 'simpleSAMLphp');
+        $this->serverconfig['SSO'] = $cfg->getBoolean('SSO', true);
 
 	}
 

--- a/www/otpform.php
+++ b/www/otpform.php
@@ -51,15 +51,13 @@
 	    try {
 			if($state['privacyidea:privacyidea:authenticationMethod'] === "authprocess") {
 				if (sspmod_privacyidea_Auth_Process_privacyidea::authenticate($state, $password, $transaction_id, $signatureData, $clientData, $registrationData)) {
-                    $session = SimpleSAML_Session::getSessionFromRequest();
-                    $session->setData('privacyidea:privacyidea', 'authenticated', true);
 					SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea:init');
 					SimpleSAML_Auth_ProcessingChain::resumeProcessing($state);
 				} else {
 					SimpleSAML_Logger::debug("privacyIDEA: User entered wrong OTP");
 				}
 			} elseif ($state['privacyidea:privacyidea:authenticationMethod'] === "authsource") {
-				if (sspmod_privacyidea_Auth_Source_privacyidea::handleLogin($authStateId, $username, $password, $transaction_id, $signatureData, $clientData));
+				sspmod_privacyidea_Auth_Source_privacyidea::handleLogin($authStateId, $username, $password, $transaction_id, $signatureData, $clientData);
 			}
         } catch (SimpleSAML_Error_Error $e) {
             /* Login failed. Extract error code and parameters, to display the error. */


### PR DESCRIPTION
closes #95 
closes #80 

This PR uses the Expire parameter as suggested by #80. Unfortunately it is not possible to modify the auth source session from an authproc filter. SimpleSAMLphp is just not intended to be used like that.

If the incoming request was not authenticated before, it will not contain `$state["Expire"]`.