### PR TITLE
Fix pass on no token for auth proc filter

### DIFF
--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -87,11 +87,23 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
     }
 
     private function maybeTryFirstAuthentication($state) {
-        return $this->serverconfig['tryFirstAuthentication']
-            && sspmod_privacyidea_Auth_utils::authenticate(
+        if (!$this->serverconfig['tryFirstAuthentication']) {
+            return false;
+        }
+
+        $state['privacyidea:privacyidea:authenticationMethod'] = "authprocess";
+
+        try {
+            sspmod_privacyidea_Auth_utils::authenticate(
                 $state,
                 array('pass' => $this->serverconfig['tryFirstAuthPass'])
             );
+
+            return true;
+        } catch (SimpleSAML_Error_Error $error) {
+            SimpleSAML_Logger::debug("privacyIDEA: user has token");
+            return false;
+        }
     }
 
     private function triggerChallenge($state) {


### PR DESCRIPTION
Hi there. I want to thank you for your work on this module.

I think there is a bug after refactor. But I could be wrong.

Here what I found:

Module calls authentication with incorrect password to check if `passOnNoToken` is enabled for user. If it's not enabled then module receives response with `wrong otp pin` message and throws exception.

https://github.com/privacyidea/simplesamlphp-module-privacyidea/blob/e1e493171f5be00e9c2cff3944e1d2307c924e17/lib/Auth/utils.php#L259

After commit bd101403fcec537b2d7cb4e3d44623fd90b962f2 there is no try/catch around `sspmod_privacyidea_Auth_utils::authenticate` call in `sspmod_privacyidea_Auth_Process_privacyidea::maybeTryFirstAuthentication`.

https://github.com/privacyidea/simplesamlphp-module-privacyidea/blob/e1e493171f5be00e9c2cff3944e1d2307c924e17/lib/Auth/Process/privacyidea.php#L89-L95

So module doesn't catch this exception and doesn't go to do trigger challenge and open OTP form.

This PR brings that try/catch back.