### PR TITLE
Fix auth proc filter config

### DIFF
--- a/lib/Auth/Process/privacyidea.php
+++ b/lib/Auth/Process/privacyidea.php
@@ -30,8 +30,6 @@ class sspmod_privacyidea_Auth_Process_privacyidea extends SimpleSAML_Auth_Proces
 
         parent::__construct($config, $reserved);
         $this->serverconfig = $config;
-        if (!isset($this->serverconfig['tryFirstAuthentication'])) { $this->serverconfig['tryFirstAuthentication'] = false; }
-        if (!isset($this->serverconfig['doTriggerChallenge'])) { $this->serverconfig['doTriggerChallenge'] = false; }
     }
 
     /**

--- a/lib/Auth/Process/serverconfig.php
+++ b/lib/Auth/Process/serverconfig.php
@@ -21,6 +21,8 @@ class sspmod_privacyidea_Auth_Process_serverconfig extends SimpleSAML_Auth_Proce
 
         parent::__construct($config, $reserved);
         $this->serverconfig = $config;
+        if (!isset($this->serverconfig['tryFirstAuthentication'])) { $this->serverconfig['tryFirstAuthentication'] = false; }
+        if (!isset($this->serverconfig['doTriggerChallenge'])) { $this->serverconfig['doTriggerChallenge'] = false; }
     }
 
     /**


### PR DESCRIPTION
Hello maintainers! Thanks for your work!

Commit 3f844871ef99deb0a407414af42f49d94d1cf320 adds lines
https://github.com/privacyidea/simplesamlphp-module-privacyidea/blob/e1e493171f5be00e9c2cff3944e1d2307c924e17/lib/Auth/Process/privacyidea.php#L33-L34

But these defaults break config merging in `sspmod_privacyidea_Auth_utils::buildServerconfig`
https://github.com/privacyidea/simplesamlphp-module-privacyidea/blob/e1e493171f5be00e9c2cff3944e1d2307c924e17/lib/Auth/utils.php#L199-L205

Because `tryFirstAuthentication` and `doTriggerChallenge` are keys of config of `privacyidea:serverconfig` auth proc filter and not `privacyidea:privacyidea` one. 

After the commit these `tryFirstAuthentication` and `doTriggerChallenge` keys are set in `$this->serverconfig` of `sspmod_privacyidea_Auth_Process_privacyidea` and are passed to `sspmod_privacyidea_Auth_utils::buildServerconfig` as keys of `$overrides` parameter.

But because these keys are set in config of `privacyidea:serverconfig`  auth proc filter they are set in `$this->serverconfig` of `sspmod_privacyidea_Auth_Process_serverconfig`. So they are passed to `sspmod_privacyidea_Auth_utils::buildServerconfig` as `$config` parameter.

Here is config merging
https://github.com/privacyidea/simplesamlphp-module-privacyidea/blob/e1e493171f5be00e9c2cff3944e1d2307c924e17/lib/Auth/utils.php#L204

So after merging these keys are always set to `false` in resulting config. To fix this we have to move setting these keys from `privacyidea:serverconfig` auth proc filter config to `privacyidea:privacyidea` one. But this conflicts with [current documentation of configuring auth proc filters](https://github.com/privacyidea/simplesamlphp-module-privacyidea/blob/e1e493171f5be00e9c2cff3944e1d2307c924e17/docs/privacyidea.md#method-2).

This PR moves setting these defaults from `sspmod_privacyidea_Auth_Process_privacyidea` to `sspmod_privacyidea_Auth_Process_serverconfig`.