### PR TITLE
feat: move from SimpleSAML_ classes to namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,15 @@
     "description": "Add two factor authentication like OTP to simpleSAMLphp. The second factor is managed in privacyIDEA.",
     "type": "simplesamlphp-module",
     "license": "AGPL-3.0",
+    "autoload": {
+        "psr-4": {
+            "SimpleSAML\\Module\\privacyidea\\": "lib/"
+        }
+    },
     "require": {
         "simplesamlphp/composer-module-installer": "~1.0",
-        "privacyidea/privacyidea-php-client": "~0.9.3"
+        "privacyidea/privacyidea-php-client": "~0.9.5",
+        "simplesamlphp/simplesamlphp": "^1.17",
+        "ext-json": "*"
     }
 }

--- a/lib/Auth/Logger.php
+++ b/lib/Auth/Logger.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace SimpleSAML\Module\privacyidea\Auth;
+
+use SimpleSAML\Logger;
+
 class Logger implements PILog
 {
     /**
@@ -8,7 +12,7 @@ class Logger implements PILog
      */
     public function piDebug($message)
     {
-        SimpleSAML_Logger::debug($message);
+        Logger::debug($message);
     }
 
     /**
@@ -17,6 +21,6 @@ class Logger implements PILog
      */
     public function piError($message)
     {
-        SimpleSAML_Logger::error($message);
+        Logger::error($message);
     }
 }

--- a/lib/Auth/Process/PrivacyideaAuthProc.php
+++ b/lib/Auth/Process/PrivacyideaAuthProc.php
@@ -1,8 +1,18 @@
 <?php
 
+namespace SimpleSAML\Module\privacyidea\Auth\Process;
+
 use PrivacyIdea\PHPClient\PIBadRequestException;
 use PrivacyIdea\PHPClient\PILog;
 use PrivacyIdea\PHPClient\PrivacyIDEA;
+use SimpleSAML\Auth\ProcessingFilter;
+use SimpleSAML\Auth\State;
+use SimpleSAML\Error\BadRequest;
+use SimpleSAML\Error\Exception;
+use SimpleSAML\Logger;
+use SimpleSAML\Module;
+use SimpleSAML\Module\privacyidea\Auth\utils;
+use SimpleSAML\Utils\HTTP;
 
 /**
  * This authentication processing filter allows you to add a second step
@@ -12,7 +22,7 @@ use PrivacyIdea\PHPClient\PrivacyIDEA;
  * @author Jean-Pierre Höhmann <jean-pierre.hoehmann@netknights.it>
  * @author Lukas Matusiewicz <lukas.matusiewicz@netknights.it>
  */
-class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Auth_ProcessingFilter implements PILog
+class PrivacyideaAuthProc extends ProcessingFilter implements PILog
 {
     /* @var array This contains the authproc configuration which is set in metadata */
     private $authProcConfig;
@@ -60,7 +70,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
             }
         } else
         {
-            SimpleSAML_Logger::error("privacyIDEA: privacyIDEA server url is not set in class: privacyidea:privacyidea in metadata.");
+           Logger::error("privacyIDEA: privacyIDEA server url is not set in class: privacyidea:privacyidea in metadata.");
         }
     }
 
@@ -71,7 +81,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
      */
     public function process(&$state)
     {
-        SimpleSAML_Logger::info("privacyIDEA Auth Proc Filter: Entering process function.");
+        Logger::info("privacyIDEA Auth Proc Filter: Entering process function.");
         assert('array' === gettype($state));
 
         // Update state before starting the authentication process
@@ -81,26 +91,26 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         // It can be used to configure that a user does not need to provide a second factor when logging in from the local network.
         if (!empty($this->authProcConfig['excludeClientIPs']))
         {
-            $state['privacyIDEA']['enabled'][0] = $this->matchIP(sspmod_privacyidea_Auth_utils::getClientIP(), $this->authProcConfig['excludeClientIPs']);
+            $state['privacyIDEA']['enabled'][0] = $this->matchIP(utils::getClientIP(), $this->authProcConfig['excludeClientIPs']);
         }
 
         // If set to "true" in config, selectively disable the privacyIDEA authentication using the entityID and/or SAML attributes.
         if (!empty($this->authProcConfig['checkEntityID']) && $this->authProcConfig['checkEntityID'] === 'true')
         {
-            $stateID = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
+            $stateID = State::saveState($state, 'privacyidea:privacyidea');
             $stateID = $this->checkEntityID($this->authProcConfig, $stateID);
-            $state = SimpleSAML_Auth_State::loadState($stateID, 'privacyidea:privacyidea');
+            $state = State::loadState($stateID, 'privacyidea:privacyidea');
         }
 
         // Check if privacyIDEA is disabled by a filter
-        if (sspmod_privacyidea_Auth_utils::checkPIAbility($state, $this->authProcConfig) === true)
+        if (utils::checkPIAbility($state, $this->authProcConfig) === true)
         {
-            SimpleSAML_Logger::debug("privacyIDEA: privacyIDEA is disabled by a filter");
+            Logger::debug("privacyIDEA: privacyIDEA is disabled by a filter");
             return;
         }
 
         $username = $state["Attributes"][$this->authProcConfig['uidKey']][0];
-        $stateID = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
+        $stateID = State::saveState($state, 'privacyidea:privacyidea');
 
         // Check if it should be controlled that user has no tokens and a new token should be enrolled.
         if (!empty($this->authProcConfig['doEnrollToken']) && $this->authProcConfig['doEnrollToken'] === 'true')
@@ -111,15 +121,15 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         // Check if all the challenges should be triggered at once and if possible, do it
         if (!empty($this->authProcConfig['doTriggerChallenge']) && $this->authProcConfig['doTriggerChallenge'] === 'true')
         {
-            $stateID = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
+            $stateID = State::saveState($state, 'privacyidea:privacyidea');
             if (!$this->pi->serviceAccountAvailable())
             {
-                SimpleSAML_Logger::error('privacyIDEA: service account or password is not set in config. Cannot to do trigger challenge.');
+                Logger::error('privacyIDEA: service account or password is not set in config. Cannot to do trigger challenge.');
             } else
             {
                 //try {
                 $response = $this->pi->triggerChallenge($username);
-                $stateID = sspmod_privacyidea_Auth_utils::processPIResponse($stateID, $response);
+                $stateID = utils::processPIResponse($stateID, $response);
                 //} catch (PIBadRequestException $e) {
                 // show some text in ui "Authentication server unreachable."
 
@@ -128,7 +138,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         } elseif (!empty($this->authProcConfig['tryFirstAuthentication']) && $this->authProcConfig['tryFirstAuthentication'] === 'true')
         {
 
-            $response = sspmod_privacyidea_Auth_utils::authenticatePI($state,
+            $response = utils::authenticatePI($state,
                                                                       array('pass' => $this->authProcConfig['tryFirstAuthPass']),
                                                                       $this->authProcConfig);
 
@@ -138,17 +148,17 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
             }
         }
 
-        $state = SimpleSAML_Auth_State::loadState($stateID, 'privacyidea:privacyidea');
+        $state = State::loadState($stateID, 'privacyidea:privacyidea');
 
         // Procfilters work already done. Save the state and go to formbuilder.php to authenticate
         // Set authprocess as authentication method and save the state
         $state['privacyidea:privacyidea']['authenticationMethod'] = "authprocess";
         $state['privacyidea:privacyidea:ui']['step'] = 2;
-        $stateID = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
+        $stateID = State::saveState($state, 'privacyidea:privacyidea');
 
         // Go to otpform
-        $url = SimpleSAML_Module::getModuleURL('privacyidea/formbuilder.php');
-        SimpleSAML_Utilities::redirectTrustedURL($url, array('StateId' => $stateID));
+        $url = Module::getModuleURL('privacyidea/formbuilder.php');
+        HTTP::redirectTrustedURL($url, array('StateId' => $stateID));
     }
 
     /**
@@ -163,12 +173,12 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         assert('string' === gettype($username));
         assert('string' === gettype($stateID));
 
-        $state = SimpleSAML_Auth_State::loadState($stateID, 'privacyidea:privacyidea');
+        $state = State::loadState($stateID, 'privacyidea:privacyidea');
 
         // Error if no serviceAccount or servicePass
         if ($this->pi->serviceAccountAvailable() === false)
         {
-            SimpleSAML_Logger::error("privacyIDEA: service account for token enrollment is not set!");
+            Logger::error("privacyIDEA: service account for token enrollment is not set!");
         } else
         {
             // Compose params
@@ -181,7 +191,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
 
             if (!empty($response->errorMessage))
             {
-                SimpleSAML_Logger::error("PrivacyIDEA server: Error code: " . $response->errorCode . ", Error message: " . $response->errorMessage);
+                Logger::error("PrivacyIDEA server: Error code: " . $response->errorCode . ", Error message: " . $response->errorMessage);
                 $state['privacyidea:privacyidea']['errorCode'] = $response->errorCode;
                 $state['privacyidea:privacyidea']['errorMessage'] = $response->errorMessage;
             }
@@ -189,7 +199,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
             // Nullcheck
             if ($response === null)
             {
-                throw new SimpleSAML_Error_BadRequest(
+                throw new BadRequest(
                     "privacyIDEA: We were not able to read the response from the PI server.");
             }
 
@@ -199,7 +209,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
             {
                 $state['privacyidea:tokenEnrollment']['tokenQR'] = $response->detail->googleurl->img;
             }
-            return SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
+            return State::saveState($state, 'privacyidea:privacyidea');
         }
         return "";
     }
@@ -249,8 +259,8 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
      */
     private function checkEntityID($authProcConfig, $stateID)
     {
-        SimpleSAML_Logger::debug("Checking requesting entity ID for privacyIDEA");
-        $state = SimpleSAML_Auth_State::loadState($stateID, 'privacyidea:privacyidea');
+        Logger::debug("Checking requesting entity ID for privacyIDEA");
+        $state = State::loadState($stateID, 'privacyidea:privacyidea');
 
         $excludeEntityIDs = $authProcConfig['excludeEntityIDs'] ?: array();
         $includeAttributes = $authProcConfig['includeAttributes'] ?: array();
@@ -262,13 +272,13 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         $requestEntityID = $state["Destination"]["entityid"];
 
         // if the requesting entityID matches the given list set the return parameter to false
-        SimpleSAML_Logger::debug("privacyidea:checkEntityID: Requesting entityID is " . $requestEntityID);
+        Logger::debug("privacyidea:checkEntityID: Requesting entityID is " . $requestEntityID);
         $matchedEntityIDs = $this->strMatchesRegArr($requestEntityID, $excludeEntityIDs);
         if ($matchedEntityIDs)
         {
             $ret = false;
             $entityIDKey = $matchedEntityIDs[0];
-            SimpleSAML_Logger::debug("privacyidea:checkEntityID: Matched entityID is " . $entityIDKey);
+            Logger::debug("privacyidea:checkEntityID: Matched entityID is " . $entityIDKey);
 
             // if there is also a match for any attribute value in the includeAttributes
             // fall back to the default return value: true
@@ -285,7 +295,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
                             if (!empty($matchedAttrs))
                             {
                                 $ret = true;
-                                SimpleSAML_Logger::debug("privacyidea:checkEntityID: Requesting entityID in " .
+                                Logger::debug("privacyidea:checkEntityID: Requesting entityID in " .
                                                          "list, but excluded by at least one attribute regexp \"" . $attrKey .
                                                          "\" = \"" . $matchedAttrs[0] . "\".");
                                 break;
@@ -293,20 +303,20 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
                         }
                     } else
                     {
-                        SimpleSAML_Logger::debug("privacyidea:checkEntityID: attribute key " .
+                        Logger::debug("privacyidea:checkEntityID: attribute key " .
                                                  $attrKey . " not contained in request");
                     }
                 }
             }
         } else
         {
-            SimpleSAML_Logger::debug("privacyidea:checkEntityID: Requesting entityID " .
+            Logger::debug("privacyidea:checkEntityID: Requesting entityID " .
                                      $requestEntityID . " not matched by any regexp.");
         }
 
         $state[$setPath][$setKey][0] = $ret;
 
-        $stateID = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
+        $stateID = State::saveState($state, 'privacyidea:privacyidea');
 
         if ($ret)
         {
@@ -315,7 +325,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         {
             $retStr = "false";
         }
-        SimpleSAML_Logger::debug("Setting \$state[" . $setPath . "][" . $setKey . "][0] = " . $retStr . ".");
+        Logger::debug("Setting \$state[" . $setPath . "][" . $setKey . "][0] = " . $retStr . ".");
 
         return $stateID;
     }
@@ -337,11 +347,11 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
             {
                 $reg = "/" . $reg . "/";
             }
-            SimpleSAML_Logger::debug("privacyidea:checkEntityID: test regexp " . $reg . " against the string " . $str);
+            Logger::debug("privacyidea:checkEntityID: test regexp " . $reg . " against the string " . $str);
 
             if (preg_match($reg, $str))
             {
-                array_push($retArr, $reg);
+                $retArr[] = $reg;
             }
         }
         return $retArr;
@@ -353,7 +363,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
      */
     public function piDebug($message)
     {
-        SimpleSAML_Logger::debug($message);
+        Logger::debug($message);
     }
 
     /**
@@ -362,6 +372,6 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
      */
     public function piError($message)
     {
-        SimpleSAML_Logger::error($message);
+        Logger::error($message);
     }
 }

--- a/lib/Auth/Source/AuthSourceLoginHandler.php
+++ b/lib/Auth/Source/AuthSourceLoginHandler.php
@@ -1,11 +1,20 @@
 <?php
 
+namespace SimpleSAML\Module\privacyidea\Auth\Source;
+
 use PrivacyIdea\PHPClient\PIResponse;
+use SimpleSAML\Auth\Source;
+use SimpleSAML\Auth\State;
+use SimpleSAML\Error\Exception;
+use SimpleSAML\Logger;
+use SimpleSAML\Module;
+use SimpleSAML\Module\privacyidea\Auth\utils;
+use SimpleSAML\Utils\HTTP;
 
 /**
  * This is the helper class for PrivacyideaAuthSource.php
  */
-class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
+class AuthSourceLoginHandler
 {
     /**
      * This function will process the login for auth source.
@@ -18,13 +27,13 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
         assert('array' === gettype($stateID));
         assert('array' === gettype($formParams));
 
-        SimpleSAML_Logger::debug("auth source login..."
+        Logger::debug("auth source login..."
                                  . "\nFormParams:\n"
                                  . print_r($formParams, true));
 
-        $state = SimpleSAML_Auth_State::loadState($stateID, 'privacyidea:privacyidea');
+        $state = State::loadState($stateID, 'privacyidea:privacyidea');
 
-        $source = SimpleSAML_Auth_Source::getById($state['privacyidea:privacyidea']["AuthId"]);
+        $source = Source::getById($state['privacyidea:privacyidea']["AuthId"]);
         if (!$source)
         {
             throw new Exception('Could not find authentication source with ID ' . $state["AuthId"]);
@@ -39,12 +48,12 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
         }
 
         $step = $state['privacyidea:privacyidea:ui']['step'];
-        //SimpleSAML_Logger::debug("STEP: " . $step);
+        //Logger::debug("STEP: " . $step);
         $response = null;
         if ($step == 1)
         {
             $state['privacyidea:privacyidea']['username'] = $username;
-            $stateID = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
+            $stateID = State::saveState($state, 'privacyidea:privacyidea');
 
             if (array_key_exists("doTriggerChallenge", $source->authSourceConfig)
                 && $source->authSourceConfig["doTriggerChallenge"] === 'true')
@@ -63,20 +72,20 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
             }
         } elseif ($step > 1)
         {
-            $response = sspmod_privacyidea_Auth_utils::authenticatePI($state, $formParams, $source->authSourceConfig);
-            $stateID = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
+            $response = utils::authenticatePI($state, $formParams, $source->authSourceConfig);
+            $stateID = State::saveState($state, 'privacyidea:privacyidea');
         } else
         {
-            SimpleSAML_Logger::error("UNDEFINED STEP: " . $step);
+            Logger::error("UNDEFINED STEP: " . $step);
         }
 
         if ($response != null)
         {
             self::checkAuthenticationComplete($state, $response, $source->authSourceConfig);
-            $stateID = sspmod_privacyidea_Auth_utils::processPIResponse($stateID, $response);
+            $stateID = utils::processPIResponse($stateID, $response);
         }
 
-        $state = SimpleSAML_Auth_State::loadState($stateID, 'privacyidea:privacyidea');
+        $state = State::loadState($stateID, 'privacyidea:privacyidea');
 
         // Increase steps counter
         if (empty($state['privacyidea:privacyidea']['errorMessage']))
@@ -84,10 +93,10 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
             $state['privacyidea:privacyidea:ui']['step'] = $step + 1;
         }
 
-        //SimpleSAML_Logger::error("NEW STEP: " . $state['privacyidea:privacyidea:ui']['step']);
-        $stateID = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
-        $url = SimpleSAML_Module::getModuleURL('privacyidea/formbuilder.php');
-        SimpleSAML_Utilities::redirectTrustedURL($url, array('StateId' => $stateID));
+        //Logger::error("NEW STEP: " . $state['privacyidea:privacyidea:ui']['step']);
+        $stateID = State::saveState($state, 'privacyidea:privacyidea');
+        $url = Module::getModuleURL('privacyidea/formbuilder.php');
+        HTTP::redirectTrustedURL($url, array('StateId' => $stateID));
     }
 
     /**
@@ -108,7 +117,7 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
             $state['Attributes'] = $completeAttributes;
 
             // Return control to simpleSAMLphp after successful authentication.
-            SimpleSAML_Auth_Source::completeAuth($state);
+            Source::completeAuth($state);
         }
     }
 
@@ -133,7 +142,7 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
         foreach ($keys as $key)
         {
 
-            SimpleSAML_Logger::debug("privacyidea        key: " . $key);
+            Logger::debug("privacyidea        key: " . $key);
             $attributeValue = $userAttributes[$key];
 
             if ($attributeValue)
@@ -142,8 +151,8 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
                 $attributeKey = @$authSourceConfig['attributemap'][$key] ?: $key;
                 $attributes[$attributeKey] = is_array($attributeValue) ? $attributeValue : array($attributeValue);
 
-                SimpleSAML_Logger::debug("privacyidea key: " . $attributeKey);
-                SimpleSAML_Logger::debug("privacyidea value: " . print_r($attributeValue, TRUE));
+                Logger::debug("privacyidea key: " . $attributeKey);
+                Logger::debug("privacyidea value: " . print_r($attributeValue, TRUE));
             }
         }
 
@@ -152,8 +161,8 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
         foreach ($authSourceConfig['detailmap'] as $key => $mappedKey)
         {
 
-            SimpleSAML_Logger::debug("privacyidea        key: " . print_r($key, TRUE));
-            SimpleSAML_Logger::debug("privacyidea mapped key: " . print_r($mappedKey, TRUE));
+            Logger::debug("privacyidea        key: " . print_r($key, TRUE));
+            Logger::debug("privacyidea mapped key: " . print_r($mappedKey, TRUE));
 
             $attributeValue = $detailAttributes->$key;
             $attributes[$mappedKey] = is_array($attributeValue) ? $attributeValue : array($attributeValue);
@@ -164,8 +173,8 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
         foreach ($authSourceConfig['concatenationmap'] as $key => $mappedKey)
         {
 
-            SimpleSAML_Logger::debug("privacyidea        key: " . print_r($key, TRUE));
-            SimpleSAML_Logger::debug("privacyidea mapped key: " . print_r($mappedKey, TRUE));
+            Logger::debug("privacyidea        key: " . print_r($key, TRUE));
+            Logger::debug("privacyidea mapped key: " . print_r($mappedKey, TRUE));
 
             $concatenationArr = explode(",", $key);
             $concatenationValues = array();
@@ -179,7 +188,7 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
             $attributes[$mappedKey] = array($concatenationString);
         }
 
-        SimpleSAML_Logger::debug("privacyidea Array returned: " . print_r($attributes, True));
+        Logger::debug("privacyidea Array returned: " . print_r($attributes, True));
         return $attributes;
     }
 
@@ -189,10 +198,10 @@ class sspmod_privacyidea_Auth_Source_AuthSourceLoginHandler
      */
     private static function checkIdLegality($id)
     {
-        $sid = SimpleSAML_Utilities::parseStateID($id);
+        $sid = State::parseStateID($id);
         if (!is_null($sid['url']))
         {
-            SimpleSAML_Utilities::checkURLAllowed($sid['url']);
+            HTTP::checkURLAllowed($sid['url']);
         }
     }
 }

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -1,7 +1,14 @@
 <?php
 
+namespace SimpleSAML\Module\privacyidea\Auth\Source;
+
 use PrivacyIdea\PHPClient\PILog;
 use PrivacyIdea\PHPClient\PrivacyIDEA;
+use SimpleSAML\Auth\State;
+use SimpleSAML\Logger;
+use SimpleSAML\Module;
+use SimpleSAML\Module\core\Auth\UserPassBase;
+use SimpleSAML\Utils\HTTP;
 
 const DEFAULT_UID_KEYS = array("username", "surname", "email", "givenname", "mobile", "phone", "realm", "resolver");
 
@@ -40,7 +47,7 @@ const DEFAULT_UID_KEYS = array("username", "surname", "email", "givenname", "mob
  * which is based on Radius.php
  *
  */
-class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_Auth_UserPassBase implements PILog
+class PrivacyideaAuthSource extends UserPassBase implements PILog
 {
     /* @var array The serverconfig is listed in this array */
     public $authSourceConfig;
@@ -114,11 +121,11 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
     public function authenticate(&$state)
     {
         assert('array' === gettype($state));
-        SimpleSAML_Logger::debug("privacyIDEA AUTH SOURCE authenticate...");
+        Logger::debug("privacyIDEA AUTH SOURCE authenticate...");
 
         // We are going to need the authID in order to retrieve this authentication source later.
         $state['privacyidea:privacyidea']['AuthId'] = self::getAuthId();
-        SimpleSAML_Logger::debug("privacyIDEA AUTH SOURCE stateID: " . $state['privacyidea:privacyidea']['AuthId']);
+        Logger::debug("privacyIDEA AUTH SOURCE stateID: " . $state['privacyidea:privacyidea']['AuthId']);
         $state['privacyidea:privacyidea']['transactionID'] = "";
         $state['privacyidea:privacyidea']['authenticationMethod'] = "authsource";
 
@@ -133,21 +140,21 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
         $state['privacyidea:privacyidea:ui']['passFieldHint'] = @$this->authSourceConfig['passFieldHint'] ?: "";
         $state['privacyidea:privacyidea:ui']['loadCounter'] = "1";
 
-        $stateID = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
-        SimpleSAML_Logger::debug("Saved state privacyidea:privacyidea from Source/privacyidea.php");
+        $stateID = State::saveState($state, 'privacyidea:privacyidea');
+        Logger::debug("Saved state privacyidea:privacyidea from Source/privacyidea.php");
 
-        $url = SimpleSAML_Module::getModuleURL('privacyidea/formbuilder.php');
-        SimpleSAML_Utilities::redirectTrustedURL($url, array('StateId' => $stateID));
+        $url = Module::getModuleURL('privacyidea/formbuilder.php');
+        HTTP::redirectTrustedURL($url, array('StateId' => $stateID));
     }
 
     public function piDebug($message)
     {
-        SimpleSAML_Logger::debug("PrivacyIDEA AUTHSOURCE: " . $message);
+        Logger::debug("PrivacyIDEA AUTHSOURCE: " . $message);
     }
 
     public function piError($message)
     {
-        SimpleSAML_Logger::error("PrivacyIDEA AUTHSOURCE: " . $message);
+        Logger::error("PrivacyIDEA AUTHSOURCE: " . $message);
     }
 
     /**
@@ -160,7 +167,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
     protected function login($username, $password)
     {
         // Stub.
-        SimpleSAML_Logger::debug("privacyIDEA AUTHSOURCE LOGIN");
+        Logger::debug("privacyIDEA AUTHSOURCE LOGIN");
         return;
     }
 }

--- a/templates/loginform.php
+++ b/templates/loginform.php
@@ -1,5 +1,7 @@
 <?php
 
+use SimpleSAML\Module;
+
 // Set default scenario if isn't set
 if (!empty($this->data['authProcFilterScenario']))
 {
@@ -32,7 +34,7 @@ if (!empty($this->data['passFieldHint']))
 /*$head = '';
 if ($this->data['u2fSignRequest']) {
     // Add javascript for U2F support before including the header.
-    $head .= '<script type="text/javascript" src="' . htmlspecialchars(SimpleSAML_Module::getModuleUrl('privacyidea/js/u2f-api.js'), ENT_QUOTES) . '"></script>';
+    $head .= '<script type="text/javascript" src="' . htmlspecialchars(Module::getModuleUrl('privacyidea/js/u2f-api.js'), ENT_QUOTES) . '"></script>';
 }*/
 
 $this->data['header'] = $this->t('{privacyidea:privacyidea:header}');
@@ -47,7 +49,7 @@ if (strlen($this->data['username']) > 0)
 }
 
 $this->data['head'] .= '<link rel="stylesheet" href="'
-    . htmlspecialchars(SimpleSAML_Module::getModuleUrl('privacyidea/css/loginform.css'), ENT_QUOTES)
+    . htmlspecialchars(Module::getModuleUrl('privacyidea/css/loginform.css'), ENT_QUOTES)
     . '" media="screen" />';
 
 $this->includeAtTemplateBase('includes/header.php');
@@ -286,10 +288,10 @@ if (!empty($this->data['links']))
 }
 ?>
 
-    <script src="<?php echo htmlspecialchars(SimpleSAML_Module::getModuleUrl('privacyidea/js/webauthn-client/pi-webauthn.js'), ENT_QUOTES) ?>">
+    <script src="<?php echo htmlspecialchars(Module::getModuleUrl('privacyidea/js/webauthn-client/pi-webauthn.js'), ENT_QUOTES) ?>">
     </script>
 
-    <script src="<?php echo htmlspecialchars(SimpleSAML_Module::getModuleUrl('privacyidea/js/u2f-api.js'), ENT_QUOTES) ?>">
+    <script src="<?php echo htmlspecialchars(Module::getModuleUrl('privacyidea/js/u2f-api.js'), ENT_QUOTES) ?>">
     </script>
 
     <meta id="privacyidea-step" name="privacyidea-step" content="<?php echo $this->data['step'] ?>">
@@ -311,7 +313,7 @@ if (!empty($this->data['links']))
     echo htmlspecialchars(json_encode($translations));
     ?>">
 
-    <script src="<?php echo htmlspecialchars(SimpleSAML_Module::getModuleUrl('privacyidea/js/loginform.js'), ENT_QUOTES) ?>">
+    <script src="<?php echo htmlspecialchars(Module::getModuleUrl('privacyidea/js/loginform.js'), ENT_QUOTES) ?>">
     </script>
 
 <?php

--- a/themes/google/default/includes/header.php
+++ b/themes/google/default/includes/header.php
@@ -1,5 +1,6 @@
 <?php
 
+use SimpleSAML\Module;
 
 /**
  * Support the htmlinject hook, which allows modules to change header, pre and post body on all pages.
@@ -23,7 +24,7 @@ if (array_key_exists('pageid', $this->data)) {
         'page' => $this->data['pageid']
     );
 
-    SimpleSAML_Module::callHooks('htmlinject', $hookinfo);
+    Module::callHooks('htmlinject', $hookinfo);
 }
 
 // - o - o - o - o - o - o - o - o - o - o - o - o -


### PR DESCRIPTION
Use namespaces instead of the deprecated underscored classes. This eliminates warnings on newer versions of SimpleSAMLphp.

BREAKING CHANGE: minimum SSP version is 1.17.0

SimpleSAMLphp 1.17 and older versions contain several [security vulnerabilities](https://simplesamlphp.org/security), including [signature verification bypass](https://simplesamlphp.org/security/201911-01), so they should not be used anymore.