### PR TITLE
catch connection exceptions

### DIFF
--- a/lib/Auth/Process/PrivacyideaAuthProc.php
+++ b/lib/Auth/Process/PrivacyideaAuthProc.php
@@ -106,8 +106,20 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
             }
             else
             {
-                $response = $this->pi->triggerChallenge($username);
-                $stateId = sspmod_privacyidea_Auth_Utils::processPIResponse($stateId, $response);
+                $response = null;
+                try
+                {
+                    $response = $this->pi->triggerChallenge($username);
+                }
+                catch (Exception $e)
+                {
+                    sspmod_privacyidea_Auth_Utils::handlePrivacyIDEAException($e, $state);
+                }
+
+                if ($response != null)
+                {
+                    $stateId = sspmod_privacyidea_Auth_Utils::processPIResponse($stateId, $response);
+                }
             }
         }
         elseif (!empty($this->authProcConfig['tryFirstAuthentication']) && $this->authProcConfig['tryFirstAuthentication'] === 'true')

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -181,7 +181,14 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
             {
                 if (!empty($username) && $source->pi->serviceAccountAvailable())
                 {
-                    $response = $source->pi->triggerChallenge($username);
+                    try
+                    {
+                        $response = $source->pi->triggerChallenge($username);
+                    }
+                    catch (Exception $e)
+                    {
+                        sspmod_privacyidea_Auth_Utils::handlePrivacyIDEAException($e, $state);
+                    }
                 }
             }
             elseif (array_key_exists("doSendPassword", $source->authSourceConfig)
@@ -189,13 +196,29 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
             {
                 if (!empty($username))
                 {
-                    $response = $source->pi->validateCheck($username, $password);
+                    try
+                    {
+                        $response = $source->pi->validateCheck($username, $password);
+                    }
+                    catch (Exception $e)
+                    {
+                        sspmod_privacyidea_Auth_Utils::handlePrivacyIDEAException($e, $state);
+                    }
                 }
             }
+            // Save the state at the end of step
+            $stateId = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
         }
         elseif ($step > 1)
         {
-            $response = sspmod_privacyidea_Auth_Utils::authenticatePI($state, $formParams);
+            try
+            {
+                $response = sspmod_privacyidea_Auth_Utils::authenticatePI($state, $formParams);
+            }
+            catch (Exception $e)
+            {
+                sspmod_privacyidea_Auth_Utils::handlePrivacyIDEAException($e, $state);
+            }
             $stateId = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
         }
         else

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -156,7 +156,7 @@ if ($this->data['errorCode'] !== NULL)
                                        placeholder="<?php echo htmlspecialchars($passHint, ENT_QUOTES) ?>"/>
 
                                 <strong id="message"><?php echo @$this->data['message'] ?: "" ?></strong>
-
+                                <br>
                                 <input id="otp" name="otp" type="password"
                                        placeholder="<?php echo htmlspecialchars($otpHint, ENT_QUOTES) ?>">
                                 <br><br>

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -157,13 +157,8 @@ if ($this->data['errorCode'] !== NULL)
 
                                 <strong id="message"><?php echo @$this->data['message'] ?: "" ?></strong>
 
-                                <br><br>
-                                <label for="otp" class="sr-only">
-                                    <?php echo $this->t('{privacyidea:privacyidea:otp}'); ?>
-                                </label>
-
-                                <input id="otp" name="otp" tabindex="1" type="password" value="" class="text"
-                                       placeholder="<?php echo htmlspecialchars($otpHint, ENT_QUOTES) ?>"/>
+                                <input id="otp" name="otp" type="password"
+                                       placeholder="<?php echo htmlspecialchars($otpHint, ENT_QUOTES) ?>">
                                 <br><br>
                                 <input id="submitButton" tabindex="1" class="rc-button rc-button-submit" type="submit"
                                        name="Submit"
@@ -187,7 +182,8 @@ if ($this->data['errorCode'] !== NULL)
                                        value='<?php echo @$this->data['u2fSignRequest'] ?: "" ?>'/>
 
                                 <input id="modeChanged" type="hidden" name="modeChanged" value="0"/>
-                                <input id="step" type="hidden" name="step" value="<?php echo @$this->data['step'] ?: 2 ?>"/>
+                                <input id="step" type="hidden" name="step"
+                                       value="<?php echo @$this->data['step'] ?: 2 ?>"/>
 
                                 <input id="webAuthnSignResponse" type="hidden" name="webAuthnSignResponse" value=""/>
                                 <input id="u2fSignResponse" type="hidden" name="u2fSignResponse" value=""/>
@@ -196,7 +192,8 @@ if ($this->data['errorCode'] !== NULL)
                                        value="<?php echo @$this->data['loadCounter'] ?: 1 ?>"/>
 
                                 <!-- Additional input to persist the message -->
-                                <input type="hidden" name="message" value="<?php echo @$this->data['message'] ?: "" ?>"/>
+                                <input type="hidden" name="message"
+                                       value="<?php echo @$this->data['message'] ?: "" ?>"/>
 
                                 <?php
                                 // If enrollToken load QR Code

--- a/www/FormReceiver.php
+++ b/www/FormReceiver.php
@@ -9,7 +9,11 @@ if (empty($stateId))
 $state = SimpleSAML_Auth_State::loadState($stateId, 'privacyidea:privacyidea');
 
 // Find the username
-if (isset($state['privacyidea:privacyidea']['uidKey']))
+if (array_key_exists('username', $_REQUEST))
+{
+$username = (string)$_REQUEST['username'];
+}
+elseif (isset($state['privacyidea:privacyidea']['uidKey']))
 {
     $uidKey = $state['privacyidea:privacyidea']['uidKey'];
     $username = $state['Attributes'][$uidKey][0];
@@ -17,10 +21,6 @@ if (isset($state['privacyidea:privacyidea']['uidKey']))
 elseif (isset($state['privacyidea:privacyidea']['username']))
 {
     $username = $state['privacyidea:privacyidea']['username'];
-}
-elseif (array_key_exists('username', $_REQUEST))
-{
-    $username = (string)$_REQUEST['username'];
 }
 elseif (isset($state['core:username']))
 {

--- a/www/css/loginform.css
+++ b/www/css/loginform.css
@@ -63,7 +63,6 @@ label[for=otp] {
 .sr-only {
 	border: 0 !important;
 	clip: rect(1px, 1px, 1px, 1px) !important;
-	-webkit-clip-path: inset(50%) !important;
 	clip-path: inset(50%) !important;
 	height: 1px !important;
 	margin: -1px !important;


### PR DESCRIPTION
* Wrap calls to the privacyidea client with try-catch so that exceptions that occur during the request (e.g. typo in server url) are caught and the error is shown
* Fix the order in which the username is received from the input form. Previously, the form entry was not the first in order which would cause a wrongly typed username to be used over and over again instead of using the new input