### PR TITLE
Ensure that `attributemap` actually gets applied

### DIFF
--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -59,15 +59,15 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
 
         parent::__construct($info, $config);
 
-        if (!in_array('attributemap', $config))
+        if (!array_key_exists('attributemap', $config))
         {
             $config['attributemap'] = array();
         }
-        if (!in_array('detailmap', $config))
+        if (!array_key_exists('detailmap', $config))
         {
             $config['detailmap'] = array();
         }
-        if (!in_array('concatenationmap', $config))
+        if (!array_key_exists('concatenationmap', $config))
         {
             $config['concatenationmap'] = array();
         }


### PR DESCRIPTION
`in_array` checks whether a value exists in an array, i.e.

    >>> in_array('foo',['foo'])
    => true
    >>> in_array('foo',['foo' => 'bar'])
    => false

whereas `attributemap` and friends are array keys containing lists that
map PI attributes to SAML attributes.

Without this change, the plugin doesn't provide the mapped attributes
(i.e. `samlLoginName`, `surName` etc.), but the attributes returned from
PrivacyIDEA (i.e. `username`, `surname` etc.).