### PR TITLE
Fix property access on concatenation-map

### DIFF
--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -340,7 +340,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
 
             foreach ($concatenationArr as $item)
             {
-                $concatenationValues[] = $userAttributes->$item;
+                $concatenationValues[] = $userAttributes[$item] ?? $item;
             }
 
             $concatenationString = implode(" ", $concatenationValues);


### PR DESCRIPTION
In PHP you cannot dereference array-keys via `->`, so each field from `concatenationmap` was empty because of `$userAttributes->$item`.

cc @lukasmatusiewicz 