### PR TITLE
Fix Authproc doTriggerChallenge conflict with passOnNoToken

### DIFF
--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -209,7 +209,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         'doEnrollToken'     => 'true',
         
         /**
-         *  A type of token that will be enrolled by the doEnrollToken option.
+         *  The type of token that will be enrolled by the doEnrollToken option.
          *  You can select a time based otp (totp), an event based otp (hotp) or an u2f (u2f)
          */
         'tokenType'         => 'totp',
@@ -217,7 +217,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         /**
          *  You can enable or disable trigger challenge.
          *  The value have to be a string.
-         *  NOTE: This has to be enabled for token challenges to work properly.
+         *  NOTE: This has to be enabled for challenge-response token to work properly.
          */
         'doTriggerChallenge' => 'true',
         
@@ -257,7 +257,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
          *  If you want to use passOnNoToken or passOnNoUser, you can decide, if this module should send a password to
          *  privacyIDEA. If passOnNoToken is activated and the user does not have a token, he will be passed by privacyIDEA.
          *  NOTE: Do not use it with privacyidea:tokenEnrollment.
-         *  NOTE: This will not trigger if the user has tokens that must be challenged.
+         *  NOTE: This will not trigger if the user has challenge-response token that were triggered before.
          */
         'tryFirstAuthentication' => 'true',
 

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -209,6 +209,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         'doEnrollToken'     => 'true',
         
         /**
+         *  A type of token that will be enrolled by the doEnrollToken option.
          *  You can select a time based otp (totp), an event based otp (hotp) or an u2f (u2f)
          */
         'tokenType'         => 'totp',
@@ -216,6 +217,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         /**
          *  You can enable or disable trigger challenge.
          *  The value have to be a string.
+         *  NOTE: This has to be enabled for token challenges to work properly.
          */
         'doTriggerChallenge' => 'true',
         
@@ -255,6 +257,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
          *  If you want to use passOnNoToken or passOnNoUser, you can decide, if this module should send a password to
          *  privacyIDEA. If passOnNoToken is activated and the user does not have a token, he will be passed by privacyIDEA.
          *  NOTE: Do not use it with privacyidea:tokenEnrollment.
+         *  NOTE: This will not trigger if the user has tokens that must be challenged.
          */
         'tryFirstAuthentication' => 'true',
 

--- a/lib/Auth/Process/PrivacyideaAuthProc.php
+++ b/lib/Auth/Process/PrivacyideaAuthProc.php
@@ -100,7 +100,8 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
             $stateId = $this->enrollToken($stateId, $username);
         }
 
-        // Check if triggerChallenge or a call with a static pass to /validate/check should be done
+        // Check if triggerChallenge call should be done
+        $challenged = false;
         if (!empty($this->authProcConfig['doTriggerChallenge']) && $this->authProcConfig['doTriggerChallenge'] === 'true')
         {
             // Call /validate/triggerchallenge with the service account from the configuration to trigger all token of the user
@@ -123,11 +124,15 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
 
                 if ($response != null)
                 {
+                    $challenged = !empty($response->multiChallenge);
                     $stateId = sspmod_privacyidea_Auth_Utils::processPIResponse($stateId, $response);
                 }
             }
         }
-        elseif (!empty($this->authProcConfig['tryFirstAuthentication']) && $this->authProcConfig['tryFirstAuthentication'] === 'true')
+
+        // Check if call with a static pass to /validate/check should be done
+        if (!$challenged
+            && !empty($this->authProcConfig['tryFirstAuthentication']) && $this->authProcConfig['tryFirstAuthentication'] === 'true')
         {
             // Call /validate/check with a static pass from the configuration
             // This could already end the authentication with the "passOnNoToken" policy, or it could trigger challenges

--- a/lib/Auth/Process/PrivacyideaAuthProc.php
+++ b/lib/Auth/Process/PrivacyideaAuthProc.php
@@ -101,7 +101,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         }
 
         // Check if triggerChallenge call should be done
-        $challenged = false;
+        $triggered = false;
         if (!empty($this->authProcConfig['doTriggerChallenge']) && $this->authProcConfig['doTriggerChallenge'] === 'true')
         {
             // Call /validate/triggerchallenge with the service account from the configuration to trigger all token of the user
@@ -124,14 +124,14 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
 
                 if ($response != null)
                 {
-                    $challenged = !empty($response->multiChallenge);
+                    $triggered = !empty($response->multiChallenge);
                     $stateId = sspmod_privacyidea_Auth_Utils::processPIResponse($stateId, $response);
                 }
             }
         }
 
         // Check if call with a static pass to /validate/check should be done
-        if (!$challenged
+        if (!$triggered
             && !empty($this->authProcConfig['tryFirstAuthentication']) && $this->authProcConfig['tryFirstAuthentication'] === 'true')
         {
             // Call /validate/check with a static pass from the configuration


### PR DESCRIPTION
Issue: [https://github.com/privacyidea/simplesamlphp-module-privacyidea/issues/161](https://github.com/privacyidea/simplesamlphp-module-privacyidea/issues/161)

- make doTriggerChallenge and tryFirstAuthentication in PrivacyideaAuthProc less dependent of each other.
This will allow to utilize both passOnNoToken (for users without enrolled tokens) and challenges (for users who have tokens) in the same process;
- update AuthProc options docs to be slightly more specific for related options;