### PR TITLE
Fix: otp extra & doSendPassword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea
-sync.sh
 /lib/php-client
 vendor
 composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 sync.sh
 /lib/php-client
+vendor
+composer.lock

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "www/js/webauthn-client"]
-	path = www/js/webauthn-client
-	url = https://github.com/privacyidea/webauthn-client.git
-[submodule "privacyIDEA-PHP-Client"]
-	path = lib/php-client
-	url = https://github.com/privacyidea/php-client.git

--- a/Changelog
+++ b/Changelog
@@ -45,7 +45,7 @@ Version 1.7 2018-11-20
 
 Version 1.6 2018-10-01
 
-  * Add support for multivalue attributes like groups or mobile numbers
+  * Add support for multi-value attributes like groups or mobile numbers
   * Return attributes as arrays to simpleSAMLphp
   * Code cleanup: Replace [] with array()
   * Remove debugging of attribute values
@@ -87,7 +87,7 @@ Version 1.3.1 2016-01-07
 
 Version 1.2 2015-11-25
 
-  * Add Login UI that supports Challange Response and U2F tokens.
+  * Add Login UI that supports Challenge Response and U2F tokens.
 
 
 Version 1.1 2015-11-05

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # privacyIDEA simpleSAMLphp Plugin
 
-This plugin adds flexible, enterprise-grade two factor authentication 
+This plugin adds flexible, enterprise-grade two-factor authentication 
 to simplesSAMLphp. 
 
-It enables simpleSAMLphp to do two factor authentication against 
+It enables simpleSAMLphp to do two-factor authentication against 
 a [privacyIDEA server](https://github.com/privacyidea/privacyidea), 
 that runs in your network. Users can authenticate with normal OTP tokens, 
 Challenge Response tokens like EMail and SMS or using WebAuthn and U2F devices.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "AGPL-3.0",
     "require": {
         "simplesamlphp/composer-module-installer": "~1.0",
-        "privacyidea/privacyidea-php-client": "^0.9.7"
+        "privacyidea/privacyidea-php-client": "^0.9.7",
+      "ext-json": "*"
     },
     "config": {
         "allow-plugins": {

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -49,13 +49,13 @@ You need to add the authentication source 'privacyidea' to
     
     /**
      * Here you need to enter the username of your service account from privacyIDEA server.
-     * Needed if 'doTriggerChallenge' => 'true'.
+     * Required if 'authSourceMode' => 'triggerChallenge'.
      */
     'serviceAccount'    => 'service',
 
     /**
      * Enter here the password for your service account.
-     * Needed if 'doTriggerChallenge' => 'true'.
+     * Required if 'authSourceMode' => 'triggerChallenge'.
      */
     'servicePass'       => 'service',
     
@@ -66,23 +66,15 @@ You need to add the authentication source 'privacyidea' to
     'serviceRealm'      => 'service',
     
     /**
-     * Set doTriggerChallenge to 'true' to trigger challenges prior to the login 
-     * using the configured service account. 
-     * This setting takes precedence over 'doSendPassword'.
-     * The value has to be a string.
-     * Optional.
+     * Set here the authsource mode to one of the following:
+     * 'sendPass' - (default) Login mask will contain the username field and 1 pass field.
+     * 'triggerChallenge' - Login mask will contain only the username field. This mode triggers
+     * challenges prior to the login using the configured service account (required).
+     * 'otpExtra' - Login mask will contain the username field, password field (e.g. PIN)
+     * and one extra field to attach the OTP already on the first step.
+     * Required.
      */
-    'doTriggerChallenge' => 'false',
-    
-    /**
-     * Set doSendPassword to 'true' to send a request to validate/check with the username
-     * and an empty pass prior to the login. 
-     * This can be used to trigger challenges depending on the configuration in privacyIDEA 
-     * and requires no service account. If 'doTriggerChallenge' is enabled, this setting has no effect.
-     * The value has to be a string.
-     * Optional.
-     */
-    'doSendPassword' => 'false',
+    'authSourceMode'      => 'sendPass',
     
     /**
      * Set custom hints for the OTP and password fields which will replace the placeholders.
@@ -94,6 +86,7 @@ You need to add the authentication source 'privacyidea' to
      * Set SSO to 'true' if you want to use single sign on.
      * All information required for SSO will be saved in the session.
      * After logging out, the SSO data will be removed from the session.
+     * The value has to be a string.
      * Optional.
      */
     'SSO' => 'false',
@@ -107,14 +100,6 @@ You need to add the authentication source 'privacyidea' to
      * Optional.
      */
     'preferredTokenType' => '',
-
-    /**
-     * OTP extra field:
-     * 'false' (default) - one password field for PIN or PIN and OTP together.
-     * 'true' - Password field for PIN and extra field for OTP already on the first step.
-     * Optional.
-     */
-    'otpExtra' => 'false',
 
     /**
      * This is the translation from privacyIDEA attribute names to 

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -9,75 +9,60 @@ You can use this plugin in two different ways:
     <li> AuthProc: This module does just one step of the authentication, the second factor against privacyIDEA
 </ol>
 
-NOTE: This plugin is enabled by default when installed, you do not need to enable it manually.
+NOTE: This plugin is enabled by default when installed, you do not need to enable it manually. 
+Just add the configuration to the corresponding file as explained in the following:
 
 AuthSource
 ==========
 
-You need to add the authentication source 'privacyidea' to
-`config/authsources.php`. *example-privacyidea* is the name used to identify this module, it can be changed to your liking. The following is a template configuration:
+Add the configuration to `config/authsources.php`. 
+*example-privacyidea* is the name used to identify this module, it can be changed to your liking.
+The following is a template configuration:
 
 ```PHP
 'example-privacyidea' => array(
     'privacyidea:PrivacyideaAuthSource',
 
     /**
-     * The URI (including protocol and port) of the privacyidea server.
-     * Required.
+     * The URL of the privacyidea server. Required.
      */
     'privacyideaServerURL' => 'https://your.server.com',
 
     /**
-     * Check if the hostname matches the name in the certificate.
-     * The value has to be a string.
-     * Optional. Default: true.
+     * Optionally disable SSL verification. This should always be enabled in a productive environment!
+     * Values should be 'true' or 'false'. Default is 'true'.      
      */
     'sslVerifyHost' => 'true',
-
-    /**
-     * Check if the certificate is valid, signed by a trusted CA.
-     * The value has to be a string.
-     * Optional. Default: true.
-     */
     'sslVerifyPeer' => 'true',
         
     /**
-     * The realm where the user is located in.
-     * Optional.
+     * Optionally set the privacyidea realm.
      */
     'realm' => '',
     
     /**
-     * Here you need to enter the username of your service account from privacyIDEA server.
-     * Required if 'authSourceMode' => 'triggerChallenge'.
+     * Specify the username and password of your service account from privacyIDEA server.
+     * Only required if 'authSourceMode' => 'triggerChallenge'.
      */
     'serviceAccount'    => 'service',
-
-    /**
-     * Enter here the password for your service account.
-     * Required if 'authSourceMode' => 'triggerChallenge'.
-     */
     'servicePass'       => 'service',
     
     /**
-     * Enter here the realm for your service account.
-     * Optional.
+     * Optionally set the realm for your service account.
      */
-    'serviceRealm'      => 'service',
+    'serviceRealm'      => '',
     
     /**
-     * Choose one of the authentication flows:
-     * 'sendPass' - (default) Login mask will contain the username field and 1 pass field.
-     * 'triggerChallenge' - Login mask will contain only the username field. This mode triggers
+     * Required. Set one of the following authentication flows:
+     * 'sendPassword' - (default) Login interface will contain the username input and a single password/OTP input.
+     * 'triggerChallenge' - Login interface will contain only the username input. This mode triggers
      * challenges prior to the login using the configured service account (required).
-     * 'separateOTP' - Login mask will contain the username field, password field (e.g. PIN)
-     * and one additional field to attach the OTP already on the first step.
-     * Required.
+     * 'separateOTP' - Login interface will contain 3 inputs for username, password and OTP.
      */
-    'authenticationFlow'      => 'sendPass',
+    'authenticationFlow'      => 'sendPassword',
     
     /**
-     * Set custom hints for the OTP and password fields which will replace the placeholders.
+     * Set custom hints for the OTP and password fields.
      */
     'otpFieldHint' => 'OTP',
     'passFieldHint' => 'Password',
@@ -86,18 +71,16 @@ You need to add the authentication source 'privacyidea' to
      * Set SSO to 'true' if you want to use single sign on.
      * All information required for SSO will be saved in the session.
      * After logging out, the SSO data will be removed from the session.
-     * The value has to be a string.
+     * The value has to be 'true' or 'false', default is 'false'.
      * Optional.
      */
     'SSO' => 'false',
     
     /**
-     * Set preferredTokenType to your favourite token type.
+     * Optionally set a preferred token type.
      * If the chosen token is triggered, it will be used to authenticate directly
      * without having to press the button for the type.
-     * Possible values are: push, webauthn or u2f.
-     * When left empty, defaults to showing an input field for OTPs.
-     * Optional.
+     * Possible values are: 'otp', 'push', 'webauthn' or 'u2f'. Default is 'otp'
      */
     'preferredTokenType' => '',
 
@@ -139,8 +122,9 @@ You need to add the authentication source 'privacyidea' to
 
 User attributes
 ---------------
-At the moment privacyIDEA will know and return the following attributes by default, that can be mapped to SAML
-attributes:
+/* add notice for privacyidea policy here */ 
+Currently, privacyIDEA will return the following attributes by default.
+They can then be mapped to SAML attributes:
 
 - username: The login name
 - surname: The real world name of the user as it is retrieved from the user source
@@ -157,7 +141,8 @@ AuthProc
 ========
 
 
-If you want to use privacyIDEA as an auth process filter, add the configuration to the metadata file (e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
+If you want to use privacyIDEA as an auth process filter, add the configuration to the metadata file,
+e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
 
 ```PHP
 'authproc' => array(
@@ -169,16 +154,14 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         'class'             => 'privacyidea:PrivacyideaAuthProc',
 
         /**
-         * Enter the URL to your privacyIDEA instance.
-         * Required.
+         * Enter the URL to your privacyIDEA instance. Required.
          */
         'privacyideaServerURL' => 'https://your.privacyidea.server',
         
         /**
-         * Enter the realm, where your users are stored.
-         * Optional.
-         */
-        'realm'             => 'realm1',
+        * Optionally set the privacyidea realm.
+        */
+        'realm' => '',
 
         /**
          * The uidKey is the username's attribute key.
@@ -186,7 +169,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
          * Example: 'uidKey' => array('uid', 'userName', 'uName').
          * Required.
          */
-        'uidKey'            => 'uid',
+        'uidKey' => 'uid',
 
         /**
          * Check if the hostname matches the name in the certificate.
@@ -281,9 +264,9 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         'tokenType'         => 'totp',
 
         /**
-         * Other authproc filters can disable 2FA if you want to.
-         * If privacyIDEA should listen to the setting, you have to enter the state's path and key.
-         * The value of this key will be set by a previous auth proc filter.
+         * Other authproc filters can disable this filter.
+         * If privacyIDEA should consider the setting, you have to enter the path and key of the state.
+         * The value of this key has to be set by a previous auth proc filter.
          * privacyIDEA will only be disabled, if the value of the key is set to false,
          * in any other situation (e.g. the key is not set or does not exist), privacyIDEA will be enabled.
          * Optional.
@@ -303,7 +286,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         /**
          * If you want to selectively disable the privacyIDEA authentication using
          * the entityID and/or SAML attributes, you may enable this.
-         * Value has to be a string.
+         * Value has to be a 'true' or 'false'.
          * Optional.
          */
         'checkEntityID'        => 'true',

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -85,9 +85,20 @@ template configuration:
     'preferredTokenType' => '',
 
     /**
-     * This is the translation from privacyIDEA attribute names to 
-     * SAML attribute names.
-     * Optional.
+     * ! REQUIRED SERVER-SIDE ACTION !
+     * To confirm the authentication, simpleSAMLphp needs some more info, than this,
+     * what privacyIDEA is sending from default in the response. To adjust and complete the server response,
+     * go to the server settings, add a policy from scope: “authorization”, and in “Action” check as follows:
+     * setting actions → add_resolver_in_response
+     * setting actions → add_user_in_response
+     * miscellaneous → application_tokentype
+     * These attributes are required to identify the user and trust the authentication which was fully
+     * provided by the external services like the privacyIDEA.
+     */
+
+    /**
+     * Translation from privacyIDEA attribute names to the SAML attribute names.
+     * Required.
      */
     'attributemap' => array(
         'username' => 'samlLoginName',
@@ -97,6 +108,11 @@ template configuration:
         'phone' => 'telePhone',
         'mobile' => 'mobilePhone'
     ),
+    
+    /**
+     * To concatenate or edit the attributes mentioned above, you can use next 2 options.
+     * If they should not be used, feel free to remove them.
+     */
 
     /**
      * You are able to concatenate attributes like the given and surname.
@@ -108,7 +124,6 @@ template configuration:
 
     /**
      * Here the detail attributes can be edited.
-     * If they should not be listed, just remove them.
      * Optional.
      */
     'detailmap' => array(

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -9,15 +9,15 @@ You can use this plugin in two different ways:
     <li> AuthProc: This module does just one step of the authentication, the second factor against privacyIDEA
 </ol>
 
-NOTE: This plugin is enabled by default when installed, you do not need to enable it manually. 
-Just add the configuration to the corresponding file as explained in the following:
+NOTE: This plugin is enabled by default when installed, you do not need to enable it manually. Just add the
+configuration to the corresponding file as explained in the following:
 
 AuthSource
 ==========
 
-Add the configuration to `config/authsources.php`. 
-*example-privacyidea* is the name used to identify this module, it can be changed to your liking.
-The following is a template configuration:
+Add the configuration to `config/authsources.php`.
+*example-privacyidea* is the name used to identify this module, it can be changed to your liking. The following is a
+template configuration:
 
 ```PHP
 'example-privacyidea' => array(
@@ -122,8 +122,7 @@ The following is a template configuration:
 
 User attributes
 ---------------
-/* add notice for privacyidea policy here */ 
-Currently, privacyIDEA will return the following attributes by default.
+/* add notice for privacyidea policy here */ Currently, privacyIDEA will return the following attributes by default.
 They can then be mapped to SAML attributes:
 
 - username: The login name
@@ -153,12 +152,12 @@ e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
     20 => array(
         'class'             => 'privacyidea:PrivacyideaAuthProc',
 
-        /**
-         * Enter the URL to your privacyIDEA instance. Required.
-         */
+       /**
+        * The URL of the privacyidea server. Required.
+        */
         'privacyideaServerURL' => 'https://your.privacyidea.server',
         
-        /**
+       /**
         * Optionally set the privacyidea realm.
         */
         'realm' => '',
@@ -172,59 +171,41 @@ e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
         'uidKey' => 'uid',
 
         /**
-         * Check if the hostname matches the name in the certificate.
-         * The value has to be a string.
-         * Optional. Default: true.
+         * Optionally disable SSL verification. This should always be enabled in a productive environment!
+         * Values should be 'true' or 'false'. Default is 'true'.      
          */
-        'sslVerifyHost'     => 'true',
-
-        /**
-         * Check if the certificate is valid, signed by a trusted CA.
-         * The value has to be a string.
-         * Optional. Default: true.
-         */
-        'sslVerifyPeer'     => 'true',
+        'sslVerifyHost' => 'true',
+        'sslVerifyPeer' => 'true',
         
         /**
          * Choose one of the authentication flows:
          * 'default' - Default authentication flow.
-         * 'triggerChallenge' - On the first step, the login mask will contain only username field. This flow triggers
-         * challenges prior to the login using the configured service account (required).
+         * 'triggerChallenge' - Before the login interface is shown, the filter will attempt to trigger challenge-response
+         * token with the specified serviceAccount
          * Required.
          */
-        'authenticationFlow'      => 'default',
+        'authenticationFlow' => 'default',
         
         /**
-         * Here you need to enter the username of your service account from privacyIDEA server.
-         * Needed if 'doTriggerChallenge' => 'true'.
+         * Specify the username and password of your service account from privacyIDEA server.
+         * Only required if 'authSourceMode' => 'triggerChallenge'.
          */
-        'serviceAccount'    => 'service',
-
-        /**
-         * Enter here the password for your service account.
-         * Needed if 'doTriggerChallenge' => 'true'.
-         */
-        'servicePass'       => 'service',
+        'serviceAccount' => 'service',
+        'servicePass' => 'service',
         
         /**
-         * Enter here the realm for your service account.
-         * Optional.
+         * Optionally set the realm for your service account.
          */
-        'serviceRealm'      => 'service',
+        'serviceRealm' => '',
         
         /**
-         * If you want to use passOnNoToken or passOnNoUser policy, you can decide, if this flow should send a password to
-         * privacyIDEA. If passOnNoToken policy is activated and the user doesn't have any token, he will be passed by the privacyIDEA.
-         * NOTE: Do not use it with 'doEnrollToken'.
+         * If you want to use the passOnNoToken or passOnNoUser policy in privacyidea, you can set this to 'true' and specify
+         * a static pass which will be sent before the actual authentication to trigger the policies in privacyidea. 
+         * NOTE: Not compatible it with 'doEnrollToken'.
          * NOTE: This won't be processed if the user has challenge-response token that were triggered before.
          * Optional.
          */
         'tryFirstAuthentication' => 'false',
-        
-        /**
-         * Password which should be used if the authentication flow is set to: 'alternativeProcess'.
-         * NOTE: Needed only by 'alternativeProcess'.
-         */
         'tryFirstAuthPass' => 'secret',
         
         /**
@@ -236,32 +217,26 @@ e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
         'SSO' => 'false',
         
         /**
-         * Set preferredTokenType to your favourite token type.
+         * Optionally set a preferred token type.
          * If the chosen token is triggered, it will be used to authenticate directly
          * without having to press the button for the type.
-         * Possible values are: push, webauthn or u2f.
-         * When left empty, defaults to showing an OTP input field.
-         * Optional.
+         * Possible values are: 'otp', 'push', 'webauthn' or 'u2f'. Default is 'otp'
          */
         'preferredTokenType' => '',
         
         /**
-         * Set custom hint for the OTP field. This will replace the default placeholder.
+         * Custom hint for the OTP field.
          */
         'otpFieldHint' => 'OTP',
         
         /**
-         * You can add this option, if you want to enroll tokens for users, who do not have one yet.
-         * The value has to be a string.
+         * Enable this if a token should be enrolled for users that do not have one.
+         * The value has to be 'true' or 'false'.
+         * Possible token types are 'hotp', 'totp' or 'u2f'
          * Optional.
          */
-        'doEnrollToken'     => 'false',
-        
-        /**
-         * The type of token that will be enrolled by the doEnrollToken option.
-         * You can select a time based otp (totp), an event based otp (hotp) or an u2f (u2f).
-         */
-        'tokenType'         => 'totp',
+        'doEnrollToken' => 'false',
+        'tokenType' => 'totp',
 
         /**
          * Other authproc filters can disable this filter.
@@ -271,8 +246,8 @@ e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
          * in any other situation (e.g. the key is not set or does not exist), privacyIDEA will be enabled.
          * Optional.
          */
-        'enabledPath'       => '',
-        'enabledKey'        => '',
+        'enabledPath' => '',
+        'enabledKey' => '',
 
         /**
          * You can exclude clients with specified ip addresses.
@@ -280,7 +255,7 @@ e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
          * The selected ip addresses do not need 2FA.
          * Optional.
          */
-        'excludeClientIPs'  => array("10.0.0.0-10.2.0.0", "192.168.178.2"),
+        'excludeClientIPs' => array("10.0.0.0-10.2.0.0", "192.168.178.2"),
 
 
         /**
@@ -289,7 +264,7 @@ e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
          * Value has to be a 'true' or 'false'.
          * Optional.
          */
-        'checkEntityID'        => 'true',
+        'checkEntityID' => 'true',
      
         /**
          * Depending on excludeEntityIDs and includeAttributes this will set the state variable 
@@ -298,8 +273,8 @@ e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
          * that they equal enabledPath and enabledKey from privacyidea:privacyidea.
          * Optional.
          */
-        'setPath'              => 'privacyIDEA',
-        'setKey'               => 'enabled',
+        'setPath' => 'privacyIDEA',
+        'setKey' => 'enabled',
         
         /**
          * The requesting SAML provider's entityID will be tested against this list of regular expressions.

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -93,7 +93,7 @@ You need to add the authentication source 'privacyidea' to
     
     /**
      * Set preferredTokenType to your favourite token type.
-     * If the choosen token is triggered, it will be used to authenticate directly
+     * If the chosen token is triggered, it will be used to authenticate directly
      * without having to press the button for the type.
      * Possible values are: push, webauthn or u2f.
      * When left empty, defaults to showing an input field for OTPs.

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -219,25 +219,25 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
          * Optional.
          */
         'serviceRealm'      => 'service',
-         
-        /**
-         * Set doTriggerChallenge to 'true' to trigger challenges prior to the login 
-         * using the configured service account. 
-         * This setting takes precedence over 'doSendPassword'.
-         * The value has to be a string.
-         * Optional.
-         */
-        'doTriggerChallenge' => 'false',
         
         /**
-         * Set doSendPassword to 'true' to send a request to validate/check with the username
-         * and an empty pass prior to the login. 
-         * This can be used to trigger challenges depending on the configuration in privacyIDEA 
-         * and requires no service account. If 'doTriggerChallenge' is enabled, this setting has no effect.
-         * The value has to be a string.
-         * Optional.
+         * Password which should be used if the authentication flow is set to: 'alternativeProcess'.
+         * NOTE: Needed only by 'alternativeProcess'.
          */
-        'doSendPassword' => 'false',
+        'passForAlternativeProcess' => 'topsecret',
+        
+        /**
+         * Choose one of the authentication flows:
+         * 'default' - Default authentication flow.
+         * 'triggerChallenge' - On the first step, the login mask will contain only username field. This flow triggers
+         * challenges prior to the login using the configured service account (required).
+         * 'alternativeProcess' - If you want to use passOnNoToken or passOnNoUser policy, you can decide, if this flow should send a password to
+         * privacyIDEA. If passOnNoToken policy is activated and the user doesn't have any token, he will be passed by the privacyIDEA.
+         * NOTE: Do not use it with 'doEnrollToken'.
+         * NOTE: This won't be processed if the user has challenge-response token that were triggered before.
+         * Required.
+         */
+        'authenticationFlow'      => 'default',
         
         /**
          * Set this to 'true' if you want to use single sign on.
@@ -258,10 +258,9 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         'preferredTokenType' => '',
         
         /**
-         * Set custom hints for the OTP and password fields
+         * Set custom hint for the OTP field. This will replace the default placeholder.
          */
         'otpFieldHint' => 'OTP',
-        'passFieldHint' => 'Password',
         
         /**
          * You can add this option, if you want to enroll tokens for users, who do not have one yet.
@@ -286,21 +285,6 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
          */
         'enabledPath'       => '',
         'enabledKey'        => '',
-
-        /**
-         * If you want to use passOnNoToken or passOnNoUser, you can decide, if this module should send a password to
-         * privacyIDEA. If passOnNoToken is activated and the user does not have a token, he will be passed by privacyIDEA.
-         * NOTE: Do not use it with privacyidea:tokenEnrollment.
-         * NOTE: This will not trigger if the user has challenge-response token that were triggered before.
-         * Optional.
-         */
-        'tryFirstAuthentication' => 'false',
-
-        /**
-         * You can decide, which password should be used for tryFirstAuthentication
-         * Optional.
-         */
-        'tryFirstAuthPass' => 'simpleSAMLphp',
 
         /**
          * You can exclude clients with specified ip addresses.

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -85,18 +85,6 @@ template configuration:
     'preferredTokenType' => '',
 
     /**
-     * ! REQUIRED SERVER-SIDE ACTION !
-     * To confirm the authentication, simpleSAMLphp needs some more info, than this,
-     * what privacyIDEA is sending from default in the response. To adjust and complete the server response,
-     * go to the server settings, add a policy from scope: “authorization”, and in “Action” check as follows:
-     * setting actions → add_resolver_in_response
-     * setting actions → add_user_in_response
-     * miscellaneous → application_tokentype
-     * These attributes are required to identify the user and trust the authentication which was fully
-     * provided by the external services like the privacyIDEA.
-     */
-
-    /**
      * Translation from privacyIDEA attribute names to the SAML attribute names.
      * Required.
      */
@@ -137,8 +125,15 @@ template configuration:
 
 User attributes
 ---------------
-/* add notice for privacyidea policy here */ Currently, privacyIDEA will return the following attributes by default.
-They can then be mapped to SAML attributes:
+To complete the authentication with SAML in AuthSource mode, SAML expects user attributes to be returned.
+These attributes will be received from privacyIDEA upon completing the authentication.
+However, this has to be enabled by creating a policy in privacyIDEA with the following values:
+Scope:  authorization
+Actions from section "setting_actions": "add_resolver_in_response", "add_user_in_response"
+Actions from section "miscellaneous": "application_tokentype
+
+The attributes can then be mapped to SAML attributes using the "attributemap" setting described in the config template above.
+Examples for those attributes are:
 
 - username: The login name
 - surname: The real world name of the user as it is retrieved from the user source

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -201,7 +201,16 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
          * Optional. Default: true.
          */
         'sslVerifyPeer'     => 'true',
-
+        
+        /**
+         * Choose one of the authentication flows:
+         * 'default' - Default authentication flow.
+         * 'triggerChallenge' - On the first step, the login mask will contain only username field. This flow triggers
+         * challenges prior to the login using the configured service account (required).
+         * Required.
+         */
+        'authenticationFlow'      => 'default',
+        
         /**
          * Here you need to enter the username of your service account from privacyIDEA server.
          * Needed if 'doTriggerChallenge' => 'true'.
@@ -221,23 +230,19 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         'serviceRealm'      => 'service',
         
         /**
-         * Password which should be used if the authentication flow is set to: 'alternativeProcess'.
-         * NOTE: Needed only by 'alternativeProcess'.
-         */
-        'passForAlternativeProcess' => 'topsecret',
-        
-        /**
-         * Choose one of the authentication flows:
-         * 'default' - Default authentication flow.
-         * 'triggerChallenge' - On the first step, the login mask will contain only username field. This flow triggers
-         * challenges prior to the login using the configured service account (required).
-         * 'alternativeProcess' - If you want to use passOnNoToken or passOnNoUser policy, you can decide, if this flow should send a password to
+         * If you want to use passOnNoToken or passOnNoUser policy, you can decide, if this flow should send a password to
          * privacyIDEA. If passOnNoToken policy is activated and the user doesn't have any token, he will be passed by the privacyIDEA.
          * NOTE: Do not use it with 'doEnrollToken'.
          * NOTE: This won't be processed if the user has challenge-response token that were triggered before.
-         * Required.
+         * Optional.
          */
-        'authenticationFlow'      => 'default',
+        'tryFirstAuthentication' => 'false',
+        
+        /**
+         * Password which should be used if the authentication flow is set to: 'alternativeProcess'.
+         * NOTE: Needed only by 'alternativeProcess'.
+         */
+        'tryFirstAuthPass' => 'secret',
         
         /**
          * Set this to 'true' if you want to use single sign on.

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -69,7 +69,7 @@ You need to add the authentication source 'privacyidea' to
      * Set doNotSendPass to 'true' to send a request to validate/check with the username
      * and an empty pass prior to the login.
      * This can be used to trigger challenges depending on the configuration in privacyIDEA 
-     * and requires no service account. If 'doTriggerChallenge' is enabled, this setting has no effect.
+     * and requires no service account. If 'doTriggerChallenge' is enabled, this setting will only hide the pass field.
      * The value have to be a string.
      * Optional.
      */

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -29,14 +29,14 @@ You need to add the authentication source 'privacyidea' to
 
     /**
      * Check if the hostname matches the name in the certificate.
-     * The value have to be a string.
+     * The value has to be a string.
      * Optional. Default: true.
      */
     'sslVerifyHost' => 'true',
 
     /**
      * Check if the certificate is valid, signed by a trusted CA.
-     * The value have to be a string.
+     * The value has to be a string.
      * Optional. Default: true.
      */
     'sslVerifyPeer' => 'true',
@@ -69,7 +69,7 @@ You need to add the authentication source 'privacyidea' to
      * Set doTriggerChallenge to 'true' to trigger challenges prior to the login 
      * using the configured service account. 
      * This setting takes precedence over 'doSendPassword'.
-     * The value have to be a string.
+     * The value has to be a string.
      * Optional.
      */
     'doTriggerChallenge' => 'false',
@@ -79,7 +79,7 @@ You need to add the authentication source 'privacyidea' to
      * and an empty pass prior to the login. 
      * This can be used to trigger challenges depending on the configuration in privacyIDEA 
      * and requires no service account. If 'doTriggerChallenge' is enabled, this setting has no effect.
-     * The value have to be a string.
+     * The value has to be a string.
      * Optional.
      */
     'doSendPassword' => 'false',
@@ -158,10 +158,10 @@ At the moment privacyIDEA will know and return the following attributes by defau
 attributes:
 
 - username: The login name
-- surname: The real world name of the user as it is retrieved from the user source 
-- givenname: The real world name of the user as it is retrieved from the user source 
-- mobile: The mobile phone number of the user as it is retrieved from the user source 
-- phone: The phone number of the user as it is retrieved from the user source 
+- surname: The real world name of the user as it is retrieved from the user source
+- givenname: The real world name of the user as it is retrieved from the user source
+- mobile: The mobile phone number of the user as it is retrieved from the user source
+- phone: The phone number of the user as it is retrieved from the user source
 - email: The email address of the user as it is retrieved from the user source
 
 The list can be extended by including custom attributes in the attributemap. If the privacyIDEA server returns an
@@ -172,7 +172,7 @@ AuthProc
 ========
 
 
-If you want to use privacyIDEA as an auth process filter, add the configuration to the metadata file (e.g. `simplesaml/metadata/saml20-idp-hosted.php`. 
+If you want to use privacyIDEA as an auth process filter, add the configuration to the metadata file (e.g. `simplesaml/metadata/saml20-idp-hosted.php`.
 
 ```PHP
 'authproc' => array(
@@ -205,14 +205,14 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
 
         /**
          * Check if the hostname matches the name in the certificate.
-         * The value have to be a string.
+         * The value has to be a string.
          * Optional. Default: true.
          */
         'sslVerifyHost'     => 'true',
 
         /**
          * Check if the certificate is valid, signed by a trusted CA.
-         * The value have to be a string.
+         * The value has to be a string.
          * Optional. Default: true.
          */
         'sslVerifyPeer'     => 'true',
@@ -239,7 +239,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
          * Set doTriggerChallenge to 'true' to trigger challenges prior to the login 
          * using the configured service account. 
          * This setting takes precedence over 'doSendPassword'.
-         * The value have to be a string.
+         * The value has to be a string.
          * Optional.
          */
         'doTriggerChallenge' => 'false',
@@ -249,7 +249,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
          * and an empty pass prior to the login. 
          * This can be used to trigger challenges depending on the configuration in privacyIDEA 
          * and requires no service account. If 'doTriggerChallenge' is enabled, this setting has no effect.
-         * The value have to be a string.
+         * The value has to be a string.
          * Optional.
          */
         'doSendPassword' => 'false',
@@ -280,7 +280,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         
         /**
          * You can add this option, if you want to enroll tokens for users, who do not have one yet.
-         * The value have to be a string.
+         * The value has to be a string.
          * Optional.
          */
         'doEnrollToken'     => 'false',
@@ -329,7 +329,7 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
         /**
          * If you want to selectively disable the privacyIDEA authentication using
          * the entityID and/or SAML attributes, you may enable this.
-         * Value have to be a string.
+         * Value has to be a string.
          * Optional.
          */
         'checkEntityID'        => 'true',

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -22,7 +22,7 @@ You need to add the authentication source 'privacyidea' to
     'privacyidea:PrivacyideaAuthSource',
 
     /**
-     * The URI (including protocol and port) of the privacyidea server
+     * The URI (including protocol and port) of the privacyidea server.
      * Required.
      */
     'privacyideaServerURL' => 'https://your.server.com',

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -66,15 +66,15 @@ You need to add the authentication source 'privacyidea' to
     'serviceRealm'      => 'service',
     
     /**
-     * Set here the authsource mode to one of the following:
+     * Choose one of the authentication flows:
      * 'sendPass' - (default) Login mask will contain the username field and 1 pass field.
      * 'triggerChallenge' - Login mask will contain only the username field. This mode triggers
      * challenges prior to the login using the configured service account (required).
-     * 'otpExtra' - Login mask will contain the username field, password field (e.g. PIN)
-     * and one extra field to attach the OTP already on the first step.
+     * 'separateOTP' - Login mask will contain the username field, password field (e.g. PIN)
+     * and one additional field to attach the OTP already on the first step.
      * Required.
      */
-    'authSourceMode'      => 'sendPass',
+    'authenticationFlow'      => 'sendPass',
     
     /**
      * Set custom hints for the OTP and password fields which will replace the placeholders.

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -66,13 +66,14 @@ You need to add the authentication source 'privacyidea' to
     'doTriggerChallenge' => 'true',
     
     /**
-     *  Set doSendPassword to 'true' to send a request to validate/check with the username
-     *  and an empty pass prior to the login. 
-     *  This can be used to trigger challenges depending on the configuration in privacyIDEA 
-     *  and requires no service account. If 'doTriggerChallenge' is enabled, this setting has no effect.
-     *  The value have to be a string.
+     * Set doNotSendPass to 'true' to send a request to validate/check with the username
+     * and an empty pass prior to the login.
+     * This can be used to trigger challenges depending on the configuration in privacyIDEA 
+     * and requires no service account. If 'doTriggerChallenge' is enabled, this setting has no effect.
+     * The value have to be a string.
+     * Optional.
      */
-    'doSendPassword' => 'true',
+    'doNotSendPass' => 'false',
     
     /**
      * Set custom hints for the OTP and password fields

--- a/docs/privacyidea.md
+++ b/docs/privacyidea.md
@@ -21,62 +21,71 @@ You need to add the authentication source 'privacyidea' to
 'example-privacyidea' => array(
     'privacyidea:PrivacyideaAuthSource',
 
-    /* 
+    /**
      * The URI (including protocol and port) of the privacyidea server
      * Required.
      */
     'privacyideaServerURL' => 'https://your.server.com',
 
-    /*
+    /**
      * Check if the hostname matches the name in the certificate.
      * The value have to be a string.
-     * Optional.
+     * Optional. Default: true.
      */
-    'sslVerifyHost' => 'false',
+    'sslVerifyHost' => 'true',
 
-    /*
+    /**
      * Check if the certificate is valid, signed by a trusted CA.
      * The value have to be a string.
-     * Optional.
+     * Optional. Default: true.
      */
-    'sslVerifyPeer' => 'false',
+    'sslVerifyPeer' => 'true',
         
-    /*
+    /**
      * The realm where the user is located in.
      * Optional.
      */
     'realm' => '',
     
     /**
-     *  Here you need to enter the username of your service account
+     * Here you need to enter the username of your service account from privacyIDEA server.
+     * Needed if 'doTriggerChallenge' => 'true'.
      */
     'serviceAccount'    => 'service',
 
     /**
-     *  Enter here the password for your service account
+     * Enter here the password for your service account.
+     * Needed if 'doTriggerChallenge' => 'true'.
      */
     'servicePass'       => 'service',
     
     /**
-     *  Set doTriggerChallenge to 'true' to trigger challenges prior to the login 
-     *  using the configured service account. 
-     *  This setting takes precedence over 'doSendPassword'.
-     *  The value have to be a string.
+     * Enter here the realm for your service account.
+     * Optional.
      */
-    'doTriggerChallenge' => 'true',
+    'serviceRealm'      => 'service',
     
     /**
-     * Set doNotSendPass to 'true' to send a request to validate/check with the username
-     * and an empty pass prior to the login.
-     * This can be used to trigger challenges depending on the configuration in privacyIDEA 
-     * and requires no service account. If 'doTriggerChallenge' is enabled, this setting will only hide the pass field.
+     * Set doTriggerChallenge to 'true' to trigger challenges prior to the login 
+     * using the configured service account. 
+     * This setting takes precedence over 'doSendPassword'.
      * The value have to be a string.
      * Optional.
      */
-    'doNotSendPass' => 'false',
+    'doTriggerChallenge' => 'false',
     
     /**
-     * Set custom hints for the OTP and password fields
+     * Set doSendPassword to 'true' to send a request to validate/check with the username
+     * and an empty pass prior to the login. 
+     * This can be used to trigger challenges depending on the configuration in privacyIDEA 
+     * and requires no service account. If 'doTriggerChallenge' is enabled, this setting has no effect.
+     * The value have to be a string.
+     * Optional.
+     */
+    'doSendPassword' => 'false',
+    
+    /**
+     * Set custom hints for the OTP and password fields which will replace the placeholders.
      */
     'otpFieldHint' => 'OTP',
     'passFieldHint' => 'Password',
@@ -85,6 +94,7 @@ You need to add the authentication source 'privacyidea' to
      * Set SSO to 'true' if you want to use single sign on.
      * All information required for SSO will be saved in the session.
      * After logging out, the SSO data will be removed from the session.
+     * Optional.
      */
     'SSO' => 'false',
     
@@ -94,6 +104,7 @@ You need to add the authentication source 'privacyidea' to
      * without having to press the button for the type.
      * Possible values are: push, webauthn or u2f.
      * When left empty, defaults to showing an input field for OTPs.
+     * Optional.
      */
     'preferredTokenType' => '',
 
@@ -101,10 +112,11 @@ You need to add the authentication source 'privacyidea' to
      * OTP extra field:
      * 'false' (default) - one password field for PIN or PIN and OTP together.
      * 'true' - Password field for PIN and extra field for OTP already on the first step.
+     * Optional.
      */
-    'otpextra' => 'false',
+    'otpExtra' => 'false',
 
-    /*
+    /**
      * This is the translation from privacyIDEA attribute names to 
      * SAML attribute names.
      * Optional.
@@ -118,15 +130,15 @@ You need to add the authentication source 'privacyidea' to
         'mobile' => 'mobilePhone'
     ),
 
-    /*
+    /**
      * You are able to concatenate attributes like the given and surname.
      * Optional.
      */
     'concatenationmap' => array(
-        'givenname,surname' => 'fullName',
+        'givenname,surname' => 'fullName'
     ),
 
-    /*
+    /**
      * Here the detail attributes can be edited.
      * If they should not be listed, just remove them.
      * Optional.
@@ -166,73 +178,87 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
 'authproc' => array(
 
     /**
-     *  Configuration for the privacyIDEA server.
+     * Configuration for the privacyIDEA server.
      */
     20 => array(
         'class'             => 'privacyidea:PrivacyideaAuthProc',
 
         /**
-         *  Enter the URL to your privacyIDEA instance
+         * Enter the URL to your privacyIDEA instance.
+         * Required.
          */
         'privacyideaServerURL' => 'https://your.privacyidea.server',
         
         /**
-         *  Enter the realm, where your users are stored (remove it or set it to '' to use default)
+         * Enter the realm, where your users are stored.
+         * Optional.
          */
         'realm'             => 'realm1',
 
         /**
-         *  The uidKey is the username's attribute key.
-         *  You can choose a single one or multiple ones. The first set will be used.
+         * The uidKey is the username's attribute key.
+         * You can choose a single one or multiple ones. The first set will be used.
+         * Example: 'uidKey' => array('uid', 'userName', 'uName').
+         * Required.
          */
         'uidKey'            => 'uid',
-        //  'uidKey'        => array('uid', 'userName', 'uName'),
 
         /**
-         *  Check if the hostname matches the name in the certificate.
-         *  The value have to be a string.
+         * Check if the hostname matches the name in the certificate.
+         * The value have to be a string.
+         * Optional. Default: true.
          */
         'sslVerifyHost'     => 'true',
 
         /**
-         *  Check if the certificate is valid, signed by a trusted CA
-         *  The value have to be a string.
+         * Check if the certificate is valid, signed by a trusted CA.
+         * The value have to be a string.
+         * Optional. Default: true.
          */
         'sslVerifyPeer'     => 'true',
 
         /**
-         *  Here you need to enter the username of your service account
+         * Here you need to enter the username of your service account from privacyIDEA server.
+         * Needed if 'doTriggerChallenge' => 'true'.
          */
         'serviceAccount'    => 'service',
 
         /**
-         *  Enter here the password for your service account
+         * Enter here the password for your service account.
+         * Needed if 'doTriggerChallenge' => 'true'.
          */
         'servicePass'       => 'service',
         
         /**
-         *  You can add this option, if you want to enroll tokens for users, who do not have one yet.
-         *  The value have to be a string.
+         * Enter here the realm for your service account.
+         * Optional.
          */
-        'doEnrollToken'     => 'true',
-        
-        /**
-         *  The type of token that will be enrolled by the doEnrollToken option.
-         *  You can select a time based otp (totp), an event based otp (hotp) or an u2f (u2f)
-         */
-        'tokenType'         => 'totp',
+        'serviceRealm'      => 'service',
          
         /**
-         *  You can enable or disable trigger challenge.
-         *  The value have to be a string.
-         *  NOTE: This has to be enabled for challenge-response token to work properly.
+         * Set doTriggerChallenge to 'true' to trigger challenges prior to the login 
+         * using the configured service account. 
+         * This setting takes precedence over 'doSendPassword'.
+         * The value have to be a string.
+         * Optional.
          */
-        'doTriggerChallenge' => 'true',
+        'doTriggerChallenge' => 'false',
+        
+        /**
+         * Set doSendPassword to 'true' to send a request to validate/check with the username
+         * and an empty pass prior to the login. 
+         * This can be used to trigger challenges depending on the configuration in privacyIDEA 
+         * and requires no service account. If 'doTriggerChallenge' is enabled, this setting has no effect.
+         * The value have to be a string.
+         * Optional.
+         */
+        'doSendPassword' => 'false',
         
         /**
          * Set this to 'true' if you want to use single sign on.
          * All information required for SSO will be saved in the session.
          * After logging out, the SSO data will be removed from the session.
+         * Optional.
          */
         'SSO' => 'false',
         
@@ -242,78 +268,101 @@ If you want to use privacyIDEA as an auth process filter, add the configuration 
          * without having to press the button for the type.
          * Possible values are: push, webauthn or u2f.
          * When left empty, defaults to showing an input field for OTPs.
+         * Optional.
          */
         'preferredTokenType' => '',
         
         /**
          * Set custom hints for the OTP and password fields
          */
-        'otpFieldHint' => 'OTP'
-        'passFieldHint' => 'Password'
+        'otpFieldHint' => 'OTP',
+        'passFieldHint' => 'Password',
+        
+        /**
+         * You can add this option, if you want to enroll tokens for users, who do not have one yet.
+         * The value have to be a string.
+         * Optional.
+         */
+        'doEnrollToken'     => 'false',
+        
+        /**
+         * The type of token that will be enrolled by the doEnrollToken option.
+         * You can select a time based otp (totp), an event based otp (hotp) or an u2f (u2f).
+         */
+        'tokenType'         => 'totp',
 
         /**
-         *  Other authproc filters can disable 2FA if you want to.
-         *  If privacyIDEA should listen to the setting, you have to enter the state's path and key.
-         *  The value of this key will be set by a previous auth proc filter.
-         *  privacyIDEA will only be disabled, if the value of the key is set to false,
-         *  in any other situation (e.g. the key is not set or does not exist), privacyIDEA will be enabled.
+         * Other authproc filters can disable 2FA if you want to.
+         * If privacyIDEA should listen to the setting, you have to enter the state's path and key.
+         * The value of this key will be set by a previous auth proc filter.
+         * privacyIDEA will only be disabled, if the value of the key is set to false,
+         * in any other situation (e.g. the key is not set or does not exist), privacyIDEA will be enabled.
+         * Optional.
          */
         'enabledPath'       => '',
         'enabledKey'        => '',
 
         /**
-         *  If you want to use passOnNoToken or passOnNoUser, you can decide, if this module should send a password to
-         *  privacyIDEA. If passOnNoToken is activated and the user does not have a token, he will be passed by privacyIDEA.
-         *  NOTE: Do not use it with privacyidea:tokenEnrollment.
-         *  NOTE: This will not trigger if the user has challenge-response token that were triggered before.
+         * If you want to use passOnNoToken or passOnNoUser, you can decide, if this module should send a password to
+         * privacyIDEA. If passOnNoToken is activated and the user does not have a token, he will be passed by privacyIDEA.
+         * NOTE: Do not use it with privacyidea:tokenEnrollment.
+         * NOTE: This will not trigger if the user has challenge-response token that were triggered before.
+         * Optional.
          */
-        'tryFirstAuthentication' => 'true',
+        'tryFirstAuthentication' => 'false',
 
         /**
-         *  You can decide, which password should be used for tryFirstAuthentication
+         * You can decide, which password should be used for tryFirstAuthentication
+         * Optional.
          */
-        'tryFirstAuthPass' => 'simpleSAMLphp'
+        'tryFirstAuthPass' => 'simpleSAMLphp',
 
         /**
-         *  
-         *  You can exclude clients with specified ip addresses.
-         *  Enter a range like "10.0.0.0-10.2.0.0" or a single ip like "192.168.178.2"
-         *  The selected ip addresses do not need 2FA
+         * You can exclude clients with specified ip addresses.
+         * Enter a range like "10.0.0.0-10.2.0.0" or a single ip like "192.168.178.2"
+         * The selected ip addresses do not need 2FA.
+         * Optional.
          */
         'excludeClientIPs'  => array("10.0.0.0-10.2.0.0", "192.168.178.2"),
 
 
         /**
-         *  Check Entity ID is optional. If you want to selectively disable the privacyIDEA authentication using
-         *  the entityID and/or SAML attributes, you may enable this filter.
-         *  Value have to be string.
+         * If you want to selectively disable the privacyIDEA authentication using
+         * the entityID and/or SAML attributes, you may enable this.
+         * Value have to be a string.
+         * Optional.
          */
         'checkEntityID'        => 'true',
      
         /**
-         *  Depending on excludeEntityIDs and includeAttributes the filter will set the state variable 
-         *  $state[$setPath][$setPath] to true or false.
-         *  To selectively enable or disable privacyIDEA, make sure that you specify setPath and setKey such
-         *  that they equal enabledPath and enabledKey from privacyidea:privacyidea.
+         * Depending on excludeEntityIDs and includeAttributes this will set the state variable 
+         * $state[$setPath][$setPath] to true or false.
+         * To selectively enable or disable privacyIDEA, make sure that you specify setPath and setKey such
+         * that they equal enabledPath and enabledKey from privacyidea:privacyidea.
+         * Optional.
          */
         'setPath'              => 'privacyIDEA',
         'setKey'               => 'enabled',
+        
         /**
-         *  The requesting SAML provider's entityID will be tested against this list of regular expressions.
-         *  If there is a match, the filter will set the specified state variable to false and thereby disables 
-         *  privacyIDEA for this entityID The first matching expression will take precedence.
+         * The requesting SAML provider's entityID will be tested against this list of regular expressions.
+         * If there is a match, the filter will set the specified state variable to false and thereby disables 
+         * privacyIDEA for this entityID The first matching expression will take precedence.
+         * Optional.
          */
         'excludeEntityIDs' => array(
             '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/',
             '/http(.*)no2fa-provider.de/'
         ),
+        
         /**
-         *  Per value in excludeEntityIDs, you may specify another set of regular expressions to match the 
-         *  attributes in the SAML request. If there is a match in any attribute value, this filter will 
-         *  set the state variable to true and thereby enable privacyIDEA where it would be normally disabled
-         *  due to the matching entityID. This may be used to enable 2FA at this entityID only for privileged
-         *  accounts.
-         *  The key in includeAttributes must be identical to a value in excludeEntityIDs to have an effect!
+         * Per value in excludeEntityIDs, you may specify another set of regular expressions to match the 
+         * attributes in the SAML request. If there is a match in any attribute value, this filter will 
+         * set the state variable to true and thereby enable privacyIDEA where it would be normally disabled
+         * due to the matching entityID. This may be used to enable 2FA at this entityID only for privileged
+         * accounts.
+         * The key in includeAttributes must be identical to a value in excludeEntityIDs to have an effect!
+         * Optional.
          */
         'includeAttributes' => array(
             '/http(s)\/\/conditional-no2fa-provider.de\/(.*)/' => array(

--- a/lib/Auth/Process/PrivacyideaAuthProc.php
+++ b/lib/Auth/Process/PrivacyideaAuthProc.php
@@ -94,12 +94,6 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         $username = $state["Attributes"][$this->authProcConfig['uidKey']][0];
         $stateId = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
 
-        // Check if it should be controlled that user has no tokens and a new token should be enrolled.
-        if (!empty($this->authProcConfig['doEnrollToken']) && $this->authProcConfig['doEnrollToken'] === 'true')
-        {
-            $stateId = $this->enrollToken($stateId, $username);
-        }
-
         // Check if triggerChallenge call should be done
         $triggered = false;
         if (!empty($this->authProcConfig['authenticationFlow']))
@@ -135,6 +129,12 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         else
         {
             SimpleSAML_Logger::error("privacyidea: Authentication flow is not set in config. Processing default one...");
+        }
+
+        // Check if it should be controlled that user has no tokens and a new token should be enrolled.
+        if (!$triggered && !empty($this->authProcConfig['doEnrollToken']) && $this->authProcConfig['doEnrollToken'] === 'true')
+        {
+            $stateId = $this->enrollToken($stateId, $username);
         }
 
         // Check if call with a static pass to /validate/check should be done
@@ -189,7 +189,7 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         }
         else
         {
-            $genkey = 1;
+            $genkey = "1";
             $type = $this->authProcConfig['tokenType'];
             $description = "Enrolled with simpleSAMLphp";
 

--- a/lib/Auth/Process/PrivacyideaAuthProc.php
+++ b/lib/Auth/Process/PrivacyideaAuthProc.php
@@ -131,8 +131,8 @@ class sspmod_privacyidea_Auth_Process_PrivacyideaAuthProc extends SimpleSAML_Aut
         }
 
         // Check if call with a static pass to /validate/check should be done
-        if (!$triggered
-            && !empty($this->authProcConfig['tryFirstAuthentication']) && $this->authProcConfig['tryFirstAuthentication'] === 'true')
+        if (!$triggered && !empty($this->authProcConfig['tryFirstAuthentication'])
+            && $this->authProcConfig['tryFirstAuthentication'] === 'true')
         {
             // Call /validate/check with a static pass from the configuration
             // This could already end the authentication with the "passOnNoToken" policy, or it could trigger challenges

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -388,7 +388,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
             $attributes[$mappedKey] = array($concatenationString);
         }
 
-        SimpleSAML_Logger::debug("privacyIDEA: Returning following attributes: " . print_r($attributes, True));
+        SimpleSAML_Logger::debug("privacyIDEA: Attributes returned: " . print_r($attributes, True));
         return $attributes;
     }
 

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -122,6 +122,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
         $state['privacyidea:privacyidea:ui']['otpFieldHint'] = @$this->authSourceConfig['otpFieldHint'] ?: "";
         $state['privacyidea:privacyidea:ui']['passFieldHint'] = @$this->authSourceConfig['passFieldHint'] ?: "";
         $state['privacyidea:privacyidea:ui']['otpExtra'] = @$this->authSourceConfig['otpExtra'] ?: false;
+        $state['privacyidea:privacyidea:ui']['doNotSendPass'] = @$this->authSourceConfig['doNotSendPass'] ?: false;
         $state['privacyidea:privacyidea:ui']['loadCounter'] = "1";
 
         $stateId = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -216,7 +216,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
                             }
                         }
                     }
-                    elseif ($authenticationFlow === 'sendPass' || $authenticationFlow === 'separateOTP')
+                    elseif ($authenticationFlow === 'sendPassword' || $authenticationFlow === 'separateOTP')
                     {
                         // In 'separateOTP' flow, the pass and otp values are combined.
                         if (!empty($formParams['otp']))

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -235,7 +235,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
                     }
                     else
                     {
-                        SimpleSAML_Logger::error("privacyIDEA: Invalid authentication flow. Please set the 'authenticationFlow' to one of the following values: 'sendPass', 'triggerChallenge' or 'separateOTP'. Until then, the login mask contains per default 1 user field and 1 pass field.");
+                        SimpleSAML_Logger::error("privacyIDEA: Invalid authentication flow. Please set 'authenticationFlow' to one of the following values: 'sendPass', 'triggerChallenge' or 'separateOTP'. Fallback to default (sendPass)");
                         try
                         {
                             $response = $source->pi->validateCheck($username, $password);

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -171,7 +171,8 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
             $password = $formParams['pass'];
         }
         // If otpExtra is set, add it to the password
-        if (!empty($formParams['otp']) && !empty($formParams['otpExtra']) && $formParams['otpExtra'] === 'true')
+        if (!empty($formParams['otp']) && array_key_exists('otpExtra', $source->authSourceConfig)
+                && $source->authSourceConfig['otpExtra'] === 'true')
         {
             $password = $password.$formParams['otp'];
         }

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -128,9 +128,9 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
         {
             $state['privacyidea:privacyidea:ui']['passFieldHint'] = $this->authSourceConfig['passFieldHint'];
         }
-        if (!empty($this->authSourceConfig['authSourceMode']))
+        if (!empty($this->authSourceConfig['authenticationFlow']))
         {
-            $state['privacyidea:privacyidea:ui']['authSourceMode'] = $this->authSourceConfig['authSourceMode'];
+            $state['privacyidea:privacyidea:ui']['authenticationFlow'] = $this->authSourceConfig['authenticationFlow'];
         }
 
         $stateId = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
@@ -187,9 +187,9 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
 
             if (!empty($username))
             {
-                if (!array_key_exists('authSourceMode', $source->authSourceConfig))
+                if (!array_key_exists('authenticationFlow', $source->authSourceConfig))
                 {
-                    SimpleSAML_Logger::error("privacyIDEA: Authsource mode not found in the config file. Please add the 'authSourceMode' with one of the following values: 'sendPass', 'triggerChallenge' or 'otpExtra'. Until then, the login mask contains per default 1 user field and 1 pass field.");
+                    SimpleSAML_Logger::error("privacyIDEA: Authentication flow not found in the config file. Please add the 'authenticationFlow' with one of the following values: 'sendPass', 'triggerChallenge' or 'separateOTP'. Until then, the login mask contains per default 1 user field and 1 pass field.");
                     try
                     {
                         $response = $source->pi->validateCheck($username, $password);
@@ -201,8 +201,8 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
                 }
                 else
                 {
-                    $authSourceMode = $source->authSourceConfig['authSourceMode'];
-                    if ($authSourceMode === 'triggerChallenge')
+                    $authenticationFlow = $source->authSourceConfig['authenticationFlow'];
+                    if ($authenticationFlow === 'triggerChallenge')
                     {
                         if ($source->pi->serviceAccountAvailable())
                         {
@@ -216,9 +216,9 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
                             }
                         }
                     }
-                    elseif ($authSourceMode === 'sendPass' || $authSourceMode === 'otpExtra')
+                    elseif ($authenticationFlow === 'sendPass' || $authenticationFlow === 'separateOTP')
                     {
-                        // In 'otpExtra' mode, the pass and otp values are combined.
+                        // In 'separateOTP' flow, the pass and otp values are combined.
                         if (!empty($formParams['otp']))
                         {
                             $password = $password . $formParams['otp'];
@@ -235,7 +235,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
                     }
                     else
                     {
-                        SimpleSAML_Logger::error("privacyIDEA: Invalid authsource mode. Please set the 'authSourceMode' to one of the following values: 'sendPass', 'triggerChallenge' or 'otpExtra'. Until then, the login mask contains per default 1 user field and 1 pass field.");
+                        SimpleSAML_Logger::error("privacyIDEA: Invalid authentication flow. Please set the 'authenticationFlow' to one of the following values: 'sendPass', 'triggerChallenge' or 'separateOTP'. Until then, the login mask contains per default 1 user field and 1 pass field.");
                         try
                         {
                             $response = $source->pi->validateCheck($username, $password);

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -388,7 +388,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
             $attributes[$mappedKey] = array($concatenationString);
         }
 
-        SimpleSAML_Logger::debug("privacyIDEA: Attributes returned: " . print_r($attributes, True));
+        SimpleSAML_Logger::debug("privacyIDEA: Returning following attributes: " . print_r($attributes, True));
         return $attributes;
     }
 

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -180,9 +180,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
             {
                 if (!array_key_exists('authSourceMode', $source->authSourceConfig))
                 {
-                    SimpleSAML_Logger::error("privacyIDEA: Authsource mode not found in the config file. 
-                        Please add the 'authSourceMode' with one of the following values: 'sendPass', 'triggerChallenge' or 'otpExtra'.
-                        Until then, the login mask contains per default 1 user field and 1 pass field.");
+                    SimpleSAML_Logger::error("privacyIDEA: Authsource mode not found in the config file. Please add the 'authSourceMode' with one of the following values: 'sendPass', 'triggerChallenge' or 'otpExtra'. Until then, the login mask contains per default 1 user field and 1 pass field.");
                     try
                     {
                         $response = $source->pi->validateCheck($username, $password);
@@ -228,9 +226,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
                     }
                     else
                     {
-                        SimpleSAML_Logger::error("privacyIDEA: Invalid authsource mode. Please set the 'authSourceMode' to 
-                        one of the following values: 'sendPass', 'triggerChallenge' or 'otpExtra'.
-                        Until then, the login mask contains per default 1 user field and 1 pass field.");
+                        SimpleSAML_Logger::error("privacyIDEA: Invalid authsource mode. Please set the 'authSourceMode' to one of the following values: 'sendPass', 'triggerChallenge' or 'otpExtra'. Until then, the login mask contains per default 1 user field and 1 pass field.");
                         try
                         {
                             $response = $source->pi->validateCheck($username, $password);

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -90,7 +90,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
     public function authenticate(&$state)
     {
         assert('array' === gettype($state));
-        SimpleSAML_Logger::debug("privacyIDEA AuthSource authenticate");
+        SimpleSAML_Logger::info("privacyIDEA AuthSource authenticate");
 
         // SSO check if authentication should be skipped
         if (array_key_exists('SSO', $this->authSourceConfig) &&
@@ -99,7 +99,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
         {
             $session = SimpleSAML_Session::getSessionFromRequest();
             $attributes = $session->getData('privacyidea:privacyidea', 'attributes');
-            SimpleSAML_Logger("privacyIDEA: SSO retrieved attributes from session: " . print_r($attributes, true));
+            //SimpleSAML_Logger::debug("privacyIDEA: SSO retrieved attributes from session: " . print_r($attributes, true));
             $state['Attributes'] = $attributes;
             SimpleSAML_Auth_Source::completeAuth($state);
         }
@@ -171,16 +171,16 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
             $password = $formParams['pass'];
         }
         // If otpExtra is set, add it to the password
-        if (!empty($password) && !empty($formParams['otpExtra']))
+        if (!empty($password) && !empty($formParams['otpExtra']) && $formParams['otpExtra'] === 'true')
         {
-            $password = $password . $formParams['otpExtra'];
+            $password = $password.$formParams['otp'];
         }
 
         $response = null;
         if ($step == 1)
         {
             $state['privacyidea:privacyidea']['username'] = $username;
-            $stateId = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
+            $stateId = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea'); // todo unused
 
             if (array_key_exists("doTriggerChallenge", $source->authSourceConfig)
                 && $source->authSourceConfig["doTriggerChallenge"] === 'true')
@@ -198,9 +198,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
                 }
             }
             elseif ((array_key_exists("doSendPassword", $source->authSourceConfig)
-                    && $source->authSourceConfig['doSendPassword'] === 'true')
-                || (array_key_exists("otpExtra", $source->authSourceConfig)
-                    && $source->authSourceConfig['otpExtra'] === 'true'))
+                    && $source->authSourceConfig['doSendPassword'] === 'true'))
             {
                 if (!empty($username))
                 {
@@ -236,7 +234,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
 
         if ($response != null)
         {
-            $stateId = sspmod_privacyidea_Auth_Utils::processPIResponse($stateId, $response, $source->authSourceConfig);
+            $stateId = sspmod_privacyidea_Auth_Utils::processPIResponse($stateId, $response, $source->authSourceConfig); // todo 3 parameters
         }
 
         $state = SimpleSAML_Auth_State::loadState($stateId, 'privacyidea:privacyidea');

--- a/lib/Auth/Source/PrivacyideaAuthSource.php
+++ b/lib/Auth/Source/PrivacyideaAuthSource.php
@@ -119,17 +119,18 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
         $state['privacyidea:privacyidea:ui']['webAuthnSignRequest'] = "";
         $state['privacyidea:privacyidea:ui']['u2fSignRequest'] = "";
         $state['privacyidea:privacyidea:ui']['mode'] = "otp";
-        $state['privacyidea:privacyidea:ui']['otpFieldHint'] = @$this->authSourceConfig['otpFieldHint'] ?: "";
-        $state['privacyidea:privacyidea:ui']['passFieldHint'] = @$this->authSourceConfig['passFieldHint'] ?: "";
-        $state['privacyidea:privacyidea:ui']['authSourceMode'] = @$this->authSourceConfig['authSourceMode'] ?: "";
         $state['privacyidea:privacyidea:ui']['loadCounter'] = "1";
-        if(!empty($this->authSourceConfig['otpFieldHint']))
+        if (!empty($this->authSourceConfig['otpFieldHint']))
         {
             $state['privacyidea:privacyidea:ui']['otpFieldHint'] = $this->authSourceConfig['otpFieldHint'];
         }
-        if(!empty($this->authSourceConfig['passFieldHint']))
+        if (!empty($this->authSourceConfig['passFieldHint']))
         {
             $state['privacyidea:privacyidea:ui']['passFieldHint'] = $this->authSourceConfig['passFieldHint'];
+        }
+        if (!empty($this->authSourceConfig['authSourceMode']))
+        {
+            $state['privacyidea:privacyidea:ui']['authSourceMode'] = $this->authSourceConfig['authSourceMode'];
         }
 
         $stateId = SimpleSAML_Auth_State::saveState($state, 'privacyidea:privacyidea');
@@ -220,7 +221,7 @@ class sspmod_privacyidea_Auth_Source_PrivacyideaAuthSource extends sspmod_core_A
                         // In 'otpExtra' mode, the pass and otp values are combined.
                         if (!empty($formParams['otp']))
                         {
-                            $password = $password.$formParams['otp'];
+                            $password = $password . $formParams['otp'];
                         }
 
                         try

--- a/lib/Auth/Utils.php
+++ b/lib/Auth/Utils.php
@@ -81,8 +81,6 @@ class sspmod_privacyidea_Auth_Utils
         elseif ($formParams['mode'] == "u2f")
         {
             $u2fSignResponse = $formParams['u2fSignResponse'];
-            SimpleSAML_Logger::error("u2fsignresponse: ".$u2fSignResponse);
-
 
             if (empty($u2fSignResponse))
             {

--- a/lib/Auth/Utils.php
+++ b/lib/Auth/Utils.php
@@ -331,7 +331,7 @@ class sspmod_privacyidea_Auth_Utils
             if ($state['privacyidea:privacyidea']['authenticationMethod'] === "authprocess")
             {
                 // Write data for SSO if enabled
-                if (array_key_exists('SSO', $config) && $config['SSO'] == true)
+                if (array_key_exists('SSO', $config) && $config['SSO'])
                 {
                     sspmod_privacyidea_Auth_Utils::tryWriteSSO();
                 }

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -301,8 +301,8 @@ if (!empty($this->data['links']))
     </script>
 
     <meta id="privacyidea-step" name="privacyidea-step" content="<?php echo $this->data['step'] ?>">
-    <meta id="privacyidea-otp-extra" name="privacyidea-otp-extra" content="<?php if (isset($this->data['otpExtra']) && $this->data['otpExtra'] === "true") {echo "true";} ?>">
-    <meta id="privacyidea-do-not-send-pass" name="privacyidea-do-not-send-pass" content="<?php if (isset($this->data['doNotSendPass']) && $this->data['doNotSendPass'] === "true") {echo "true";} ?>">
+    <meta id="privacyidea-otp-extra" name="privacyidea-otp-extra" content="<?php if (isset($this->data['authSourceMode']) && $this->data['authSourceMode'] === "otpExtra") {echo "true";} ?>">
+    <meta id="privacyidea-hide-pass-field" name="privacyidea-hide-pass-field" content="<?php if (isset($this->data['authSourceMode']) && $this->data['authSourceMode'] === "triggerChallenge") {echo "true";} ?>">
     <meta id="privacyidea-hide-alternate" name="privacyidea-hide-alternate" content="<?php echo (
         !$this->data['pushAvailable']
         && (!isset($this->data['u2fSignRequest']) || ($this->data['u2fSignRequest']) == "")

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -302,8 +302,8 @@ if (!empty($this->data['links']))
 
     <meta id="privacyidea-step" name="privacyidea-step" content="<?php echo $this->data['step'] ?>">
     
-    <meta id="privacyidea-otp-extra" name="privacyidea-otp-extra" content="<?php if (isset($this->data['authSourceMode']) && $this->data['authSourceMode'] === "otpExtra") {echo "true";} ?>">
-    <meta id="privacyidea-hide-pass-field" name="privacyidea-hide-pass-field" content="<?php if (isset($this->data['authSourceMode']) && $this->data['authSourceMode'] === "triggerChallenge") {echo "true";} ?>">
+    <meta id="privacyidea-separate-otp" name="privacyidea-separate-otp" content="<?php if (isset($this->data['authenticationFlow']) && $this->data['authenticationFlow'] === "separateOTP") {echo "true";} ?>">
+    <meta id="privacyidea-hide-pass-field" name="privacyidea-hide-pass-field" content="<?php if (isset($this->data['authenticationFlow']) && $this->data['authenticationFlow'] === "triggerChallenge") {echo "true";} ?>">
     
     <meta id="privacyidea-hide-alternate" name="privacyidea-hide-alternate" content="
         <?php

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -190,6 +190,9 @@ if ($this->data['errorCode'] !== NULL)
                                 <input id="step" type="hidden" name="step"
                                        value="<?php echo htmlspecialchars(@$this->data['step'] ?: 2, ENT_QUOTES) ?>"/>
 
+                                <input id="otpExtra" type="hidden" name="otpExtra"
+                                       value="<?php echo htmlspecialchars(@$this->data['otpExtra'] ?: "true", ENT_QUOTES) ?>"/>
+
                                 <input id="webAuthnSignResponse" type="hidden" name="webAuthnSignResponse" value=""/>
                                 <input id="u2fSignResponse" type="hidden" name="u2fSignResponse" value=""/>
                                 <input id="origin" type="hidden" name="origin" value=""/>

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -204,6 +204,7 @@ if ($this->data['errorCode'] !== NULL)
                                 {
                                     echo htmlspecialchars($this->t('{privacyidea:privacyidea:scanTokenQR}'));
                                     ?>
+                                    <br><br>
                                     <div class="tokenQR">
                                         <?php echo '<img src="' . $this->data['tokenQR'] . '" />'; ?>
                                     </div>

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -175,7 +175,7 @@ if ($this->data['errorCode'] !== NULL)
                                        value="<?php echo htmlspecialchars(@$this->data['mode'] ?: "otp", ENT_QUOTES) ?>"/>
 
                                 <input id="pushAvailable" type="hidden" name="pushAvailable"
-                                       value="<?php echo htmlspecialchars(@$this->data['pushAvailable'] ?: "", ENT_QUOTES) ?>"/>
+                                       value="<?php echo htmlspecialchars(@$this->data['pushAvailable'] ?: "0", ENT_QUOTES) ?>"/>
 
                                 <input id="otpAvailable" type="hidden" name="otpAvailable"
                                        value="<?php echo htmlspecialchars(@$this->data['otpAvailable'] ?: "1", ENT_QUOTES) ?>"/>

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-
 <?php
 
 // Set default scenario if isn't set

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -301,8 +301,8 @@ if (!empty($this->data['links']))
     </script>
 
     <meta id="privacyidea-step" name="privacyidea-step" content="<?php echo $this->data['step'] ?>">
-    <meta id="privacyidea-otp-extra" name="privacyidea-otp-extra" content="<?php if (isset($this->data['otpExtra']) && $this->data['otpExtra']) {echo true;} ?>">
-    <meta id="privacyidea-do-not-send-pass" name="privacyidea-do-not-send-pass" content="<?php if (isset($this->data['doNotSendPass']) && $this->data['doNotSendPass']) {echo true;} ?>">
+    <meta id="privacyidea-otp-extra" name="privacyidea-otp-extra" content="<?php if (isset($this->data['otpExtra']) && $this->data['otpExtra'] === "true") {echo "true";} ?>">
+    <meta id="privacyidea-do-not-send-pass" name="privacyidea-do-not-send-pass" content="<?php if (isset($this->data['doNotSendPass']) && $this->data['doNotSendPass'] === "true") {echo "true";} ?>">
     <meta id="privacyidea-hide-alternate" name="privacyidea-hide-alternate" content="<?php echo (
         !$this->data['pushAvailable']
         && (!isset($this->data['u2fSignRequest']) || ($this->data['u2fSignRequest']) == "")

--- a/templates/LoginForm.php
+++ b/templates/LoginForm.php
@@ -190,9 +190,6 @@ if ($this->data['errorCode'] !== NULL)
                                 <input id="step" type="hidden" name="step"
                                        value="<?php echo htmlspecialchars(@$this->data['step'] ?: 2, ENT_QUOTES) ?>"/>
 
-                                <input id="otpExtra" type="hidden" name="otpExtra"
-                                       value="<?php echo htmlspecialchars(@$this->data['otpExtra'] ?: "true", ENT_QUOTES) ?>"/>
-
                                 <input id="webAuthnSignResponse" type="hidden" name="webAuthnSignResponse" value=""/>
                                 <input id="u2fSignResponse" type="hidden" name="u2fSignResponse" value=""/>
                                 <input id="origin" type="hidden" name="origin" value=""/>
@@ -304,7 +301,8 @@ if (!empty($this->data['links']))
     </script>
 
     <meta id="privacyidea-step" name="privacyidea-step" content="<?php echo $this->data['step'] ?>">
-    <meta id="privacyidea-otp-extra" name="privacyidea-otp-extra" content="<?php if (isset($this->data['otpExtra']) && $this->data['otpExtra']) {echo str_replace('"', "", $this->data['otpExtra']);} ?>">
+    <meta id="privacyidea-otp-extra" name="privacyidea-otp-extra" content="<?php if (isset($this->data['otpExtra']) && $this->data['otpExtra']) {echo true;} ?>">
+    <meta id="privacyidea-do-not-send-pass" name="privacyidea-do-not-send-pass" content="<?php if (isset($this->data['doNotSendPass']) && $this->data['doNotSendPass']) {echo true;} ?>">
     <meta id="privacyidea-hide-alternate" name="privacyidea-hide-alternate" content="<?php echo (
         !$this->data['pushAvailable']
         && (!isset($this->data['u2fSignRequest']) || ($this->data['u2fSignRequest']) == "")

--- a/www/FormBuilder.php
+++ b/www/FormBuilder.php
@@ -77,7 +77,7 @@ elseif ($state['privacyidea:privacyidea']['authenticationMethod'] === "authsourc
 
     if ($source == NULL)
     {
-        SimpleSAML_Logger::error('Could not find authentication source with ID ' . $state["privacyidea:privacyidea"]["AuthId"]);
+        SimpleSAML_Logger::error('Could not find authentication source with ID: ' . $state["privacyidea:privacyidea"]["AuthId"]);
     }
 
     $tpl->data['username'] = $username;

--- a/www/FormReceiver.php
+++ b/www/FormReceiver.php
@@ -34,7 +34,6 @@ else
 $formParams = array(
     "username" => $username,
     "pass" => array_key_exists('password', $_REQUEST) ? $_REQUEST['password'] : "",
-    "otpExtra" => array_key_exists('otpExtra', $_REQUEST) ? $_REQUEST['otpExtra'] : "",
     "otp" => array_key_exists('otp', $_REQUEST) ? $_REQUEST['otp'] : "",
     "mode" => array_key_exists('mode', $_REQUEST) ? $_REQUEST['mode'] : "otp",
     "pushAvailable" => array_key_exists('pushAvailable', $_REQUEST) ? $_REQUEST['pushAvailable'] : "false",

--- a/www/js/loginform.js
+++ b/www/js/loginform.js
@@ -73,8 +73,8 @@ if (step > "1")
     disable("AlternateLoginOptions");
 }
 
-// Handle otp extra field
-if (document.getElementById("privacyidea-otp-extra").content === "true")
+// Handle separate OTP field
+if (document.getElementById("privacyidea-separate-otp").content === "true")
 {
     enable("otp");
 }

--- a/www/js/loginform.js
+++ b/www/js/loginform.js
@@ -83,7 +83,10 @@ if (document.getElementById("privacyidea-otp-extra").content === "true")
 if (document.getElementById("privacyidea-do-not-send-pass").content === "true")
 {
     disable("password");
-    disable("otp");
+    if (step === "1")
+    {
+        disable("otp");
+    }
 }
 
 // Set alternate token button visibility

--- a/www/js/loginform.js
+++ b/www/js/loginform.js
@@ -108,7 +108,7 @@ if (value("otpAvailable") !== "1")
 
 if (value("pushAvailable") === "0" && value("webAuthnSignRequest") === "" && value("u2fSignRequest") === "")
 {
-    disable("alternateTokenDiv");
+    disable("AlternateLoginOptions");
 }
 
 if (value("mode") === "otp")
@@ -266,7 +266,7 @@ function sign_u2f_request(signRequest)
 }
 
 if (document.getElementById("privacyidea-hide-alternate").content === "true") {
-    document.getElementById("AlternateLoginOptions").classList.add("hidden");
+    disable("AlternateLoginOptions");
 }
 
 document.addEventListener("DOMContentLoaded", (event) => {

--- a/www/js/loginform.js
+++ b/www/js/loginform.js
@@ -79,6 +79,13 @@ if (document.getElementById("privacyidea-otp-extra").content === "true")
     enable("otp");
 }
 
+// Handle doNotSendPass
+if (document.getElementById("privacyidea-do-not-send-pass").content === "true")
+{
+    disable("password");
+    disable("otp");
+}
+
 // Set alternate token button visibility
 if (value("webAuthnSignRequest") === "")
 {

--- a/www/js/loginform.js
+++ b/www/js/loginform.js
@@ -79,8 +79,8 @@ if (document.getElementById("privacyidea-otp-extra").content === "true")
     enable("otp");
 }
 
-// Handle doNotSendPass
-if (document.getElementById("privacyidea-do-not-send-pass").content === "true")
+// Hide pass field if redundant
+if (document.getElementById("privacyidea-hide-pass-field").content === "true")
 {
     disable("password");
     if (step === "1")

--- a/www/js/loginform.js
+++ b/www/js/loginform.js
@@ -83,10 +83,6 @@ if (document.getElementById("privacyidea-otp-extra").content === "true")
 if (document.getElementById("privacyidea-hide-pass-field").content === "true")
 {
     disable("password");
-    if (step === "1")
-    {
-        disable("otp");
-    }
 }
 
 // Set alternate token button visibility

--- a/www/js/pi-webauthn.js
+++ b/www/js/pi-webauthn.js
@@ -133,7 +133,7 @@ var pi_webauthn = navigator.credentials ? window.pi_webauthn || {} : null;
     /**
      * Encode a binary into base64.
      *
-     * This will take a binary ArrrayBufferLike and encode it into base64.
+     * This will take a binary ArrayBufferLike and encode it into base64.
      *
      * Adapted from Base64 / binary data / UTF-8 strings utilities (#2)
      *
@@ -448,7 +448,7 @@ var pi_webauthn = navigator.credentials ? window.pi_webauthn || {} : null;
      * @type {object}
      * @property {string} challenge - The challenge from privacyIDEA.
      * @property {{id: string, type: PublicKeyCredentialType, transports: AuthenticatorTransport[]}[]} allowCredentials - Creds to try.
-     * @property {string} rpId - The relying party id the credential was created with.
+     * @property {string} rpId - The upon party id the credential was created with.
      * @property {UserVerificationRequirement} userVerification - Option to discourage, or require user verification.
      * @property {number} [timeout=60000] - Timeout in milliseconds.
      *

--- a/www/js/u2f-api.js
+++ b/www/js/u2f-api.js
@@ -36,7 +36,7 @@ u2f.EXTENSION_ID = 'kmendfapggjehodndflmmgagdbamhnfd';
 
 
 /**
- * Message types for messsages to/from the extension
+ * Message types for messages to/from the extension
  * @const
  * @enum {string}
  */
@@ -336,7 +336,7 @@ u2f.formatSignRequest_ =
     };
 
 /**
- * Format and return a register request compliant with the JS API version supported by the extension..
+ * Format and return a register request compliant with the JS API version supported by the extension.
  * @param {Array<u2f.SignRequest>} signRequests
  * @param {Array<u2f.RegisterRequest>} signRequests
  * @param {number} timeoutSeconds
@@ -669,7 +669,7 @@ u2f.responseHandler_ = function (message)
 /**
  * Dispatches an array of sign requests to available U2F tokens.
  * If the JS API version supported by the extension is unknown, it first sends a
- * message to the extension to find out the supported API version and then it sends
+ * message to the extension to find out the supported API version, and then it sends
  * the sign request.
  * @param {string=} appId
  * @param {string=} challenge
@@ -721,7 +721,7 @@ u2f.sendSignRequest = function (appId, challenge, registeredKeys, callback, opt_
  * Dispatches register requests to available U2F tokens. An array of sign
  * requests identifies already registered tokens.
  * If the JS API version supported by the extension is unknown, it first sends a
- * message to the extension to find out the supported API version and then it sends
+ * message to the extension to find out the supported API version, and then it sends
  * the register request.
  * @param {string=} appId
  * @param {Array<u2f.RegisterRequest>} registerRequests


### PR DESCRIPTION
+ Implement the authentication flows.
+ Update the authsource config template with an `authenticationFlow` option. Valid values are: `sendPass`, `triggerChallenge`, and `otpExtra`.
+ `doTriggerChallenge`, `doSendPassword` and `otpExtra` options are outdated and removed from the config template.
+  `authenticationFlow` is required. If the option isn't found or the value is invalid, the login mask contains per default: 1 username field and 1 pass field, and a proper error is written to the log.
+ Implement the `authenticationFlow` in `authproc`. Valid values: `default`, `triggerChallenge`.
+ rm submodule configuration and belonging files from the repo.
+ Fix: process token enrollment after trigger challenge if is set.