### PR TITLE
Added $username to AuthProc template data

### DIFF
--- a/www/FormBuilder.php
+++ b/www/FormBuilder.php
@@ -84,6 +84,7 @@ if ($state['privacyidea:privacyidea']['authenticationMethod'] === "authprocess")
     $tpl->data['rememberUsernameEnabled'] = true;
     $tpl->data['rememberUsernameChecked'] = true;
     $tpl->data['forceUsername'] = true;
+    $tpl->data['username'] = $username;
 
     // Enroll token's QR
     if (isset($state['privacyidea:tokenEnrollment']['tokenQR']))


### PR DESCRIPTION
Dear PrivacyIDEA support,

I think that the AuthProc Filter part is missing the username and this Pull Request adds it in the right way, I hope.

I can't get the username without it.

Best Regards,
Marco